### PR TITLE
Fix: selectID when reloading

### DIFF
--- a/www/js/selectID.js
+++ b/www/js/selectID.js
@@ -329,7 +329,7 @@
         var c;
         var data = $dlg.data('selectId');
         var noStates = (data.objects && !data.states);
-        var multiselect = (!data.noDialog && !data.buttonsDlg);
+        var multiselect = (!data.noDialog);
         // Get all states
         getAllStates(data);
 
@@ -1308,7 +1308,7 @@
                 }
                 data.selectedID = data.currentId;
 
-                if (!data.inited) {
+                if (!data.inited || !data.noDialog) {
                     data.$dlg = $dlg;
                     initTreeDialog($dlg);
                 } else {


### PR DESCRIPTION
Two small fixes for the newly implemented multiselect in the selectID dialog:
- When pressing the reload-Button on the upper left, the tree would be reinitialized without checkboxes
- When closing the window and reopening it, all the checkboxes are still selected, which is quite confusing. Now always doing a initTreeDialog when in dialog-mode.