### PR TITLE
Entfernt bei data-type = "select multiple" _('none') aus options[]

### DIFF
--- a/www/js/adapter-settings.js
+++ b/www/js/adapter-settings.js
@@ -1168,6 +1168,7 @@ function values2table(divId, values, onChange, onReady) {
                         } else {
                             options = names[i].options;
                         }
+						if (names[i].type === 'select multiple') delete options[_('none')];
                         var val = (values[v][names[i].name] === undefined ? '' : values[v][names[i].name]);
                         if (typeof val !== 'object') val = [val];
                         for (var p in options) {                                                        


### PR DESCRIPTION
Bei select multiple ist keine leere option erforderlich und sollte
auch nicht in der table angezeigt werden.