### PR TITLE
Fehler in confirmMessage()

### DIFF
--- a/www/js/adapter-settings.js
+++ b/www/js/adapter-settings.js
@@ -370,6 +370,7 @@ function confirmMessage(message, title, icon, buttons, callback) {
                 click: function (e) {
                     var id = parseInt(e.currentTarget.id.substring('dialog-confirm-button-'.length), 10);
                     var cb = $(this).data('callback');
+					$(this).data('callback', null);
                     $(this).dialog('close');
                     if (cb) cb(id);
                 }


### PR DESCRIPTION
Ohne $(this).data('callback', null) wird der callback bei Verwendung von
selbstdefinierten Buttons (confirmMessage(...,buttons,callback)) nicht
gelöscht und auch aufgerufen, wenn bei einem erneuten Aufruf von
confirmMessage(...,buttons) kein callback übergeben wird.