### PR TITLE
fix quickEdit: number with bollean value

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -2,8 +2,12 @@
     "common": {
         "name":                     "admin",
         "title":                    "ioBroker Admin",
-        "version": "2.0.7",
+        "version": "2.0.8",
         "news": {
+            "2.0.8": {
+                "en": "fix quickEdit: number with boolean value",
+                "de": "behoben: quickEdit, number mit übergebenem boolean Wert"
+            },
             "2.0.7": {
                 "en": "Sort option added to object view",
                 "de": "Sortiermöglichkeit zur Objectansicht hinzugefügt",

--- a/www/js/adminObjects.js
+++ b/www/js/adminObjects.js
@@ -646,11 +646,7 @@ function Objects(main) {
                         if (that.main.objects[id] && that.main.objects[id].common && that.main.objects[id].common.type) {
                             switch (that.main.objects[id].common.type) {
                                 case 'number':
-                                    var v = parseFloat(newValue);
-                                    if (isNaN(v)) {
-                                        v = newValue === 'false' ? 0 : ~~newValue;
-                                    }
-                                    newValue = v;
+                                    newValue = parseFloat(newValue);
                                     break;
 
                                 case 'boolean':

--- a/www/js/adminObjects.js
+++ b/www/js/adminObjects.js
@@ -646,7 +646,11 @@ function Objects(main) {
                         if (that.main.objects[id] && that.main.objects[id].common && that.main.objects[id].common.type) {
                             switch (that.main.objects[id].common.type) {
                                 case 'number':
-                                    newValue = parseFloat(newValue);
+                                    var v = parseFloat(newValue);
+                                    if (isNaN(v)) {
+                                        v = newValue === 'false' ? 0 : ~~newValue;
+                                    }
+                                    newValue = v;
                                     break;
 
                                 case 'boolean':


### PR DESCRIPTION
if pressing the state button in the admin object view on a state with type=number and role=button