### PR TITLE
[v3] Fix display of delete button for not installed adapters

### DIFF
--- a/src/js/adminAdapters.js
+++ b/src/js/adminAdapters.js
@@ -1006,7 +1006,7 @@ function Adapters(main) {
                             install: '<button data-adapter-name="' + adapter + '" class="adapter-install-submit small-button" title="' + localTexts['add instance'] + '"><i class="material-icons">add</i></button>' +
                             '<button ' + (obj.readme ? '' : 'disabled="disabled" ') + ' data-adapter-name="' + adapter + '" data-adapter-url="' + obj.readme + '" class="adapter-readme-submit small-button" title="' + localTexts['readme'] + '"><i class="material-icons">help_outline</i></button>' +
                             '<div class="small-button-empty">&nbsp;</div>' +
-                            '<button disabled="disabled" data-adapter-name="' + adapter + '" class="adapter-delete-submit small-button" title="' + localTexts['delete adapter'] + '"><i class="material-icons">delete_forever</i></button>' +
+                            '<button disabled="disabled" data-adapter-name="' + adapter + '" class="adapter-delete-submit small-button disabled" title="' + localTexts['delete adapter'] + '"><i class="material-icons">delete_forever</i></button>' +
                             ((that.main.config.expertMode) ? '<button data-adapter-name="' + adapter + '" data-target="adapters-menu" class="adapter-update-custom-submit small-button" title="' + localTexts['install specific version'] + '"><i class="material-icons">add_to_photos</i></button>' : ''),
                             // TODO do not show adapters not for this platform
                             // platform:   obj.platform, // actually there is only one platform


### PR DESCRIPTION
This is a small fix for the display of not installed adapters by adding the disabled class.

Before:
![image](https://user-images.githubusercontent.com/5904171/35200667-a83f7700-ff12-11e7-89cf-1cfe78c3936c.png)

After:
![image](https://user-images.githubusercontent.com/5904171/35200656-8ef95392-ff12-11e7-9f17-aa81311adb1e.png)

Before:
![image](https://user-images.githubusercontent.com/5904171/35200677-c6f16a78-ff12-11e7-8d45-f2500d5028da.png)

After:
![image](https://user-images.githubusercontent.com/5904171/35200693-ed1de26c-ff12-11e7-966d-2c9fb940dd66.png)
