### PR TITLE
Update admin.less

### DIFF
--- a/src/less/admin.less
+++ b/src/less/admin.less
@@ -10,6 +10,7 @@ body {
     font-family:    @iob-font;
     font-weight:    normal;
     overflow:       hidden;
+    background:     #fff;
 }
 
 /* Load material icons */


### PR DESCRIPTION
Wenn iobroker.admin über einen iframe Beispielsweise über iobroker.vis eingebunden werden soll (und dessen Hintergrund nicht #fff ist), wird für <body> eine Hintergrundfarbe benötigt.