### PR TITLE
(BuZZy1337) always addChips when input blurs

### DIFF
--- a/src/materialize-css/js/chips.js
+++ b/src/materialize-css/js/chips.js
@@ -249,6 +249,10 @@
      * Handle Input Blur
      */
     _handleInputBlur() {
+      this.addChip({
+        tag: this.$input[0].value
+      });
+      this.$input[0].value = '';
       this.$el.removeClass('focus');
     }
 

--- a/src/materialize-css/js/chips.js
+++ b/src/materialize-css/js/chips.js
@@ -263,8 +263,8 @@
     _handleInputKeydown(e) {
       Chips._keydown = true;
 
-      // enter
-      if (e.keyCode === 13) {
+      // enter - comma - semicolon - space
+      if (e.keyCode === 13 || e.keyCode === 188 || e.keyCode === 32) {
         // Override enter if autocompleting.
         if (this.hasAutocomplete &&
           this.autocomplete &&


### PR DESCRIPTION
Chips had to be added/applied by pressing ENTER.

With this change the Chips are always added regardless of how we exit the inputfield (TAB, Click on another element,...)

- Regarding https://github.com/ioBroker/ioBroker.javascript/issues/102