### PR TITLE
Make installation log selectable

### DIFF
--- a/src/indexStart.html
+++ b/src/indexStart.html
@@ -151,7 +151,7 @@
             </div>
             <div class="row textarea">
                 <div class="col s12">
-                    <textarea id="stdout" disabled="disabled" cols="120" rows="30"></textarea>
+                    <textarea id="stdout" readonly="readonly" cols="120" rows="30"></textarea>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
In Firefox, disabled `<textarea>`s are not selectable, so one cannot select or copy the installation log.
`readonly` keeps the user from editing the text but he can select and copy it.