### PR TITLE
Fix multihost adapter installation destination

### DIFF
--- a/src/js/adminAdapters.js
+++ b/src/js/adminAdapters.js
@@ -1552,13 +1552,13 @@ function Adapters(main) {
                         // Show license dialog!
                         showLicenseDialog(adapter, function (isAgree) {
                             if (isAgree) {
-                                that.main.cmdExec(null, 'add ' + adapter, function (exitCode) {
+                                that.main.cmdExec(null, 'add ' + adapter + ' ' + index + ' --host ' + host, function (exitCode) {
                                     if (!exitCode) that._postInit(true);
                                 });
                             }
                         });
                     } else {
-                        that.main.cmdExec(null, 'add ' + adapter + ' ' + index, function (exitCode) {
+                        that.main.cmdExec(null, 'add ' + adapter + ' ' + index + ' --host ' + host, function (exitCode) {
                             if (!exitCode) that._postInit(true);
                         });
                     }


### PR DESCRIPTION
Admin does not pay attention to the selected hostname when executing the "add adapter" command

Set --host parameter for ./iobroker add-command