### PR TITLE
added update indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ This project uses some icons from [Flaticon](https://www.flaticon.com/):
 - <img src="src/img/rooms/toilet.svg" height="48" /> - Icons made by [Freepik](http://www.freepik.com) from [www.flaticon.com](https://www.flaticon.com/) is licensed by [CC 3.0 BY](http://creativecommons.org/licenses/by/3.0/)
 
 ## Changelog
+### 3.6.0 (2018-09-22)
+* (foxriver76) New update states added in info channel
+* (foxriver76) Take respect to async when creating info states
+
 ### 3.5.10 (2018-09-22)
 * (bluefox) Disable too many debug outputs
 

--- a/io-package.json
+++ b/io-package.json
@@ -2,8 +2,12 @@
   "common": {
     "name": "admin",
     "title": "Admin",
-    "version": "3.5.10",
+    "version": "3.6.0",
     "news": {
+      "3.6.0": {
+        "en": "New update info states added",
+        "de": "Neue informative states über Updates hinzugefügt"
+      },
       "3.5.10": {
         "en": "Too many debug outputs were disabled",
         "de": "Zu viele Debug-Ausgaben wurden deaktiviert",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.admin",
   "description": "The adapter opens a webserver for the ioBroker admin UI.",
-  "version": "3.5.10",
+  "version": "3.6.0",
   "contributors": [
     "bluefox <dogafox@gmail.com>",
     "apollon77",


### PR DESCRIPTION
-newUpdates will only be true if the update is not known before
-lastUpdateCheck -> timestamp which indicates time of last check for updates
-updatesJson contains the adapters which are upgradeable as well as the installed and the available version
-the setup can be used to give users the ability to create custom messages e.g. trigger on new updates and let you send a mail with adapter old + new version
-changes on creating the states, due to the fact that obj has been recycled in asynchrous code (adapter.setObject), which lead to strange behaviours