### PR TITLE
Don't use that.adapter in socket.js

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -427,7 +427,7 @@ function IOSocket(server, settings, adapter, objects, states, store) {
                 }
             }
             text = '[' + cnt + ']' + text;
-            that.adapter.setState('connected', text, true);
+            adapter.setState('connected', text, true);
         }
     }
 
@@ -654,7 +654,7 @@ function IOSocket(server, settings, adapter, objects, states, store) {
                                 if (typeof callback === 'function') {
                                     callback(ip, data.rows[i].value);
                                 } else {
-                                    that.adapter.log.warn('[getHostByIp] Invalid callback')
+                                    adapter.log.warn('[getHostByIp] Invalid callback')
                                 }
                                 return;
                             }
@@ -667,7 +667,7 @@ function IOSocket(server, settings, adapter, objects, states, store) {
                                             if (typeof callback === 'function') {
                                                 callback(ip, data.rows[i].value);
                                             } else {
-                                                that.adapter.log.warn('[getHostByIp] Invalid callback')
+                                                adapter.log.warn('[getHostByIp] Invalid callback')
                                             }
                                             return;
                                         }
@@ -680,7 +680,7 @@ function IOSocket(server, settings, adapter, objects, states, store) {
                     if (typeof callback === 'function') {
                         callback(ip, null);
                     } else {
-                        that.adapter.log.warn('[getHostByIp] Invalid callback');
+                        adapter.log.warn('[getHostByIp] Invalid callback');
                     }
                 });
             }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,5 @@
     "test:unit": "mocha test/unit --exit",
     "test:integration": "mocha test/integration --exit"
   },
-  "author": "bluefox <dogafox@gmail.com>",
-  "license": "MIT"
+  "author": "bluefox <dogafox@gmail.com>"
 }


### PR DESCRIPTION
Fixes: https://github.com/ioBroker/testing/issues/13

In `lib/socket.js` the adapter instance stored in the variable `adapter`. Only 4 locations use `that.adapter` (which is never assigned to), one of which is throwing the error in the referenced issue.