### PR TITLE
Fix annoying note from Info Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ This project uses some icons from [Flaticon](https://www.flaticon.com/):
 - <img src="src/img/rooms/toilet.svg" height="48" /> - Icons made by [Freepik](http://www.freepik.com) from [www.flaticon.com](https://www.flaticon.com/) is licensed by [CC 3.0 BY](http://creativecommons.org/licenses/by/3.0/)
 
 ## Changelog
+### 3.6.5 (2019-09-02)
+* (ldittmar) Fix anoying popups from info adapter
+
 ### 3.6.4 (2019-06-03)
 * (bluefox) Update nodejs recommendation message and check to recommend nodejs 10
 

--- a/io-package.json
+++ b/io-package.json
@@ -2,8 +2,20 @@
   "common": {
     "name": "admin",
     "title": "Admin",
-    "version": "3.6.4",
+    "version": "3.6.5",
     "news": {
+      "3.6.5": {
+        "en": "Fix anoying popups from info adapter",
+        "de": "Beheben Sie ärgerliche Popups vom Info-Adapter",
+        "ru": "Исправление всплывающих всплывающих окон из адаптера",
+        "pt": "Corrija pop-ups irritantes do adaptador de informações",
+        "nl": "Bevestig vervelende pop-ups van de info-adapter",
+        "fr": "Corrige les popups ennuyeux depuis l'adaptateur info",
+        "it": "Correggi i popup di anoying dall'adattatore informazioni",
+        "es": "Arreglar ventanas emergentes molestas desde el adaptador de información",
+        "pl": "Napraw wyskakujące okienka z adaptera informacyjnego",
+        "zh-cn": "从信息适配器修复恼人的弹出窗口"
+      },
       "3.6.4": {
         "en": "Update nodejs recommendation message and check to recommend nodejs 10",
         "ru": "Обновите сообщение с рекомендацией nodejs и проверьте, чтобы рекомендовать nodejs 10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.admin",
   "description": "The adapter opens a webserver for the ioBroker admin UI.",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "contributors": [
     "bluefox <dogafox@gmail.com>",
     "apollon77",

--- a/src/js/adminInfo.js
+++ b/src/js/adminInfo.js
@@ -35,11 +35,15 @@ function InfoAdapter(main) {
     };
 
     this.showPopup = function (obj) {
-        that.main.socket.emit('getState', 'info.0.last_popup', function (err, dateObj) {
-            if (!err && dateObj) {
-                that.checkAndSetData(obj, dateObj.val);
-            }
-        });
+        if (sessionStorage.getItem('ioBroker.info.lastPopup')) {
+            that.checkAndSetData(obj, sessionStorage.getItem('ioBroker.info.lastPopup'));
+        }else{
+            that.main.socket.emit('getState', 'info.0.last_popup', function (err, dateObj) {
+                if (!err && dateObj) {
+                    that.checkAndSetData(obj, dateObj.val);
+                }
+            });
+        }
     };
 
     this.checkAndSetData = async function (messagesObj, date) {
@@ -63,6 +67,7 @@ function InfoAdapter(main) {
             that.main.showMessage(content, _("Please read these important notes:"), "error");
         }
         if (messages.length > 0) {
+            sessionStorage.setItem('ioBroker.info.lastPopup', new Date().toISOString());
             that.main.socket.emit('setState', 'info.0.last_popup', {val: new Date().toISOString(), ack: true});
         }
     };

--- a/src/js/adminInfo.js
+++ b/src/js/adminInfo.js
@@ -40,6 +40,7 @@ function InfoAdapter(main) {
         }else{
             that.main.socket.emit('getState', 'info.0.last_popup', function (err, dateObj) {
                 if (!err && dateObj) {
+                    sessionStorage.setItem('ioBroker.info.lastPopup', dateObj.val);
                     that.checkAndSetData(obj, dateObj.val);
                 }
             });


### PR DESCRIPTION
Also... dass die Info-Meldungen ständig im Admin angezeigt werden ist richtig nervig und ich weiß echt nicht warum das so ist, denn die letzte Sicht wird ja immer gespeichert, aber beim auslesen (that.main.socket.emit 'getState') steht komischerweise noch den alten Wert drin. Irgendwann stimmt alles wieder, aber ich weiss nicht genau warum und wann das passiert. Deswegen will ich hier mich mit der sessionstorage behelfen. So erscheint die Meldung nicht ständig und irgendwann greift dann auch das getState wieder und alles ist gut.

Bitte schauen ob das theoretisch funktioniert!