### PR TITLE
verify versioning with semver

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ const utils       = require('@iobroker/adapter-core'); // Get common adapter uti
 const tools 	  = require(utils.controllerDir + '/lib/tools.js');
 const SocketIO    = require('./lib/socket');
 const Web         = require('./lib/web');
+const semver      = require('semver');
 
 const ONE_HOUR_MS = 3600000;
 const ERROR_PERMISSION = 'permissionError';
@@ -217,30 +218,8 @@ function createUpdateInfo() {
 }
 
 // Helper methods
-function upToDate(a, b) {
-    a = a.split('.');
-    b = b.split('.');
-    a[0] = parseInt(a[0], 10);
-    b[0] = parseInt(b[0], 10);
-    if (a[0] > b[0]) {
-        return false;
-    } else if (a[0] < b[0]) {
-        return true;
-    } else if (a[0] === b[0]) {
-        a[1] = parseInt(a[1], 10);
-        b[1] = parseInt(b[1], 10);
-        if (a[1] > b[1]) {
-            return false;
-        } else if (a[1] < b[1]) {
-            return true;
-        } else if (a[1] === b[1]) {
-            a[2] = parseInt(a[2], 10);
-            b[2] = parseInt(b[2], 10);
-            return a[2] <= b[2];
-        }
-    } else {
-        return true;
-    }
+function upToDate(v1, v2) {
+	return semver.gt(v2, v1);
 }
 
 function writeUpdateInfo(sources) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "setup"
   ],
   "dependencies": {
+    "@iobroker/adapter-core": "^1.0.3",
     "body-parser": "^1.19.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.4",
@@ -30,9 +31,9 @@
     "passport-local": "^1.0.0",
     "passport.socketio": "^3.7.0",
     "request": "^2.88.0",
+    "semver": "^6.3.0",
     "socket.io": "1.7.2",
-    "xtend": "^4.0.2",
-    "@iobroker/adapter-core": "^1.0.3"
+    "xtend": "^4.0.2"
   },
   "devDependencies": {
     "@iobroker/testing": "^1.3.0",


### PR DESCRIPTION
This pr adds comparison of adapter versions according to semantic versioning, see https://semver.org/#backusnaur-form-grammar-for-valid-semver-versions.

This allows more precise versioning, means not only `v0.9.0` or `v1.2.3` but also `v1.0.0-beta.1` or `v1.0.0-rc.1`, etc.

## TEST
```
const semver = require('semver');

let test = [
	['v1.0.0', 'v0.0.9'],
	['v0.0.9', 'v1.0.0'],
	['v1.0.0', 'v1.0.0'],
	['v1.0.0', 'v1.0.0-beta.1'],
	['v1.0.0-beta.1', 'v1.0.0'],
	['v1.0.0-beta.2', 'v1.0.0-beta.1'],
	['v1.0.0-beta.1', 'v1.0.0-beta.2'],
	['v1.0.0-rc.1', 'v1.0.0-beta.1'],
	['v1.0.0-beta.1', 'v1.0.0-rc.1'],
	['v1.0.0', 'v1.0.0-beta.1'],
	['v1.0.0', 'v1.0.0-rc.1'],
	['v2.0.0', 'v1.0.0'],
	['v1.0.0', 'v2.0.0'],
	['v1.1.2', 'v1.1.1'],
	['v1.1.0', 'v1.1.1'],
	['v1.1.1', 'v1.1.0'],
	['v0.0.1', 'v1.1.0-beta.1'],
	['v1.1.0-beta.1', 'v0.0.1'],
];

test.forEach(version => console.log(version[0] + ' > ' + version[1] + ': ' + semver.gt(version[0], version[1])));
```

## EXPECTED RESULT
```
v1.0.0 > v0.0.9: true
v0.0.9 > v1.0.0: false
v1.0.0 > v1.0.0: false
v1.0.0 > v1.0.0-beta.1: true
v1.0.0-beta.1 > v1.0.0: false
v1.0.0-beta.2 > v1.0.0-beta.1: true
v1.0.0-beta.1 > v1.0.0-beta.2: false
v1.0.0-rc.1 > v1.0.0-beta.1: true
v1.0.0-beta.1 > v1.0.0-rc.1: false
v1.0.0 > v1.0.0-beta.1: true
v1.0.0 > v1.0.0-rc.1: true
v2.0.0 > v1.0.0: true
v1.0.0 > v2.0.0: false
v1.1.2 > v1.1.1: true
v1.1.0 > v1.1.1: false
v1.1.1 > v1.1.0: true
v0.0.1 > v1.1.0-beta.1: false
v1.1.0-beta.1 > v0.0.1: true
```