### PR TITLE
do not call adapter objects directly 

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -149,7 +149,7 @@
     ],
     "dependencies": [
       {
-        "js-controller": ">=1.2.0"
+        "js-controller": ">=2.0.0"
       }
     ],
     "type": "general",

--- a/main.js
+++ b/main.js
@@ -418,7 +418,7 @@ function getData(adapter, callback) {
 
     adapter.log.info('requesting all objects');
 
-    adapter.objects.getObjectList({include_docs: true}, (err, res) => {
+    adapter.getObjectList({include_docs: true}, (err, res) => {
         adapter.log.info('received all objects');
         if (res) {
             res = res.rows;


### PR DESCRIPTION
- because of https://github.com/ioBroker/ioBroker.js-controller/issues/359
- this needs js-c > 2.0.0
- however getObjectView in  https://github.com/ioBroker/ioBroker.admin/blob/4aca4dda23294574a11e65c0849295eb6b0e3185/main.js#L321 already requires js-c 2