### PR TITLE
fix custom handling for js-controller 2.2.x ... 

### DIFF
--- a/src/js/adminCustoms.js
+++ b/src/js/adminCustoms.js
@@ -719,18 +719,12 @@ function Customs(main) {
 
         if (ids) {
             for (var i = 0; i < ids.length; i++) {
-                var found = false;
                 var custom_ = that.main.objects[ids[i]].common.custom;
                 for (var inst in custom_) {
                     if (!custom_.hasOwnProperty(inst)) continue;
                     if (!custom_[inst].enabled) {
-                        delete custom_[inst];
-                    } else {
-                        found = true;
+                        custom_[inst] = null;
                     }
-                }
-                if (!found) {
-                    that.main.objects[ids[i]].common.custom = null;
                 }
             }
 


### PR DESCRIPTION
but my feeling tells me that this might break stuff in adapters when using js-controller <2.2.

For js-controller < 2.2 the customs object will get "null" values in there because the object is always stored completely,

While history/sql/influxdb, telegram, sourceanalytics, mqtt-client, iqontrol will break (they only check for undefined):
https://github.com/sbormann/ioBroker.iqontrol/blob/master/admin/index_m.js#L1286

From a first view it should be only iqontrol,so would be acceptable?!

PS: Needs further testing ... 