### PR TITLE
use cli restart command instead of _restart

### DIFF
--- a/src/js/adminHosts.js
+++ b/src/js/adminHosts.js
@@ -105,7 +105,7 @@ function Hosts(main) {
 
         this.$tab.find('.host-restart-submit' + selector).off('click').on('click', function () {
             that.main.waitForRestart = true;
-            that.main.cmdExec($(this).attr('data-host-name'), '_restart');
+            that.main.cmdExec($(this).attr('data-host-name'), 'restart');
         });
         this.$tab.find('.host-delete' + selector).off('click').on('click', function () {
             that.main.cmdExec(that.main.currentHost, 'host remove ' + $(this).attr('data-host-name'));


### PR DESCRIPTION
- to restart controller via admin
- otherwise, we have no clean restart, but a "kill" of all adapters and controller. This has the effect that e.g. "History" data are not stored
- fixes https://github.com/ioBroker/ioBroker.js-controller/issues/561