### PR TITLE
#638 Prevent Duplicate Event Handling on Dropdown Checkboxes

### DIFF
--- a/src/js/adapter-settings.js
+++ b/src/js/adapter-settings.js
@@ -421,10 +421,13 @@ function preInit () {
                         M.updateTextFields();
 
                         // workaround for materialize checkbox problem
-                        $('input[type="checkbox"]+span').off('click').on('click', function () {
+                        $('input[type="checkbox"]+span').off('click').on('click', function (event) {
                             var $input = $(this).prev();
                             if (!$input.prop('disabled')) {
                                 $input.prop('checked', !$input.prop('checked')).trigger('change');
+				// prevent propagation to prevent original handling from reverting our value change
+			    	event.preventDefault();
+			    	event.stopImmediatePropagation();
                             }
                         });
                     }


### PR DESCRIPTION
For #638: prevented Event Propagation which otherwise resulted in double toggle of checkbox --> thus leaving value unchanged