### PR TITLE
(simatec) WebSocket compression added

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -195,7 +195,19 @@ function SocketIO (server) {
                 done && done(true);
                 done = null;
             }
-        }
+        },
+        perMessageDeflate: {
+			zlibDeflateOptions: {
+			chunkSize: 1024,
+			memLevel: 9,
+			level: 9
+			},
+			zlibInflateOptions: {
+				chunkSize: 16 * 1024
+			},
+			clientNoContextTakeover: true,
+			serverNoContextTakeover: true
+		}
     });
 
     wss.on('connection', (ws, request) => {


### PR DESCRIPTION
I added the WebSocket compression and tested it extensively with Chrome, Safari and Edge.
On average, the charging time is halved.

With objects with a length of approx. 5MB I was able to reduce the loading time from 40-45 seconds to 16-18 seconds with a slow VPN connection with 2.4 MB in the upload.

WebSocket compression is barely noticeable in the LAN and has no effect on performance.
I have observed the behavior with htop and there is no difference in the system load.