### PR TITLE
Fix display of history data for large datasets

### DIFF
--- a/src-rx/src/components/Object/ObjectChart.js
+++ b/src-rx/src/components/Object/ObjectChart.js
@@ -156,7 +156,7 @@ class ObjectChart extends Component {
         super(props);
         let from;
         if (!this.props.from) {
-            from = new Date(this.props.from);
+            from = Date.now();
             from.setHours(from.getHours() - 24 * 7);
             this.start = from.getTime();
         } else {
@@ -350,17 +350,18 @@ class ObjectChart extends Component {
     readHistoryRange() {
         const now = new Date();
         const oldest = new Date(2000, 0, 1);
-
+// this is a code which makes problems. It is no good idea doing this!
         return this.props.socket.getHistory(this.props.obj._id, {
             instance:  this.state.historyInstance,
             start:     oldest.getTime(),
             end:       now.getTime(),
-            step:      3600000, // hourly
+            //step:      3600000, // hourly
+            limit:     1, // is that a way to make it faster?
             from:      false,
             ack:       false,
             q:         false,
             addID:     false,
-            aggregate: 'minmax'
+            aggregate: 'none'
         })
             .then(values => {
                 // remove interpolated first value

--- a/src-rx/src/components/Object/ObjectChart.js
+++ b/src-rx/src/components/Object/ObjectChart.js
@@ -739,26 +739,23 @@ class ObjectChart extends Component {
         } else if (mins === 'week') {
             now.setHours(0);
             now.setMinutes(0);
-            now.setFullYear(now.getFullYear() - 1);
             // find week start
             if (now.getDay()) { // if not sunday
                 now.setDate(now.getDate() - now.getDay() - 1);
             } else {
                 now.setDate(now.getDate() - 6);
             }
-
-            this.chart.min = now.getTime();
+            min = now.getTime();
         } else if (mins === '2weeks') {
             now.setHours(0);
             now.setMinutes(0);
-            now.setFullYear(now.getFullYear() - 1);
             // find week start
             if (now.getDay()) { // if not sunday
                 now.setDate(now.getDate() - now.getDay() - 8);
             } else {
                 now.setDate(now.getDate() - 13);
             }
-            this.chart.min = now.getTime();
+            min = now.getTime();
         } else if (mins === 'month') {
             now.setHours(0);
             now.setMinutes(0);
@@ -832,19 +829,16 @@ class ObjectChart extends Component {
         } else if (mins === 'week') {
             now.setHours(0);
             now.setMinutes(0);
-            now.setFullYear(now.getFullYear() - 1);
             // find week start
             if (now.getDay()) { // if not sunday
                 now.setDate(now.getDate() - now.getDay() - 1);
             } else {
                 now.setDate(now.getDate() - 6);
             }
-
             this.chart.min = now.getTime();
         } else if (mins === '2weeks') {
             now.setHours(0);
             now.setMinutes(0);
-            now.setFullYear(now.getFullYear() - 1);
             // find week start
             if (now.getDay()) { // if not sunday
                 now.setDate(now.getDate() - now.getDay() - 8);

--- a/src-rx/src/components/Object/ObjectHistoryData.js
+++ b/src-rx/src/components/Object/ObjectHistoryData.js
@@ -522,16 +522,18 @@ class ObjectHistoryData extends Component {
         const oldest = new Date(2000, 0, 1);
 
         this.setState({ loading: true });
+        // this is a code which makes problems. It is no good idea doing this!
         return this.props.socket.getHistory(this.props.obj._id, {
             instance:  this.state.historyInstance,
             start:     oldest.getTime(),
             end:       now.getTime(),
-            step:      3600000 * 24 * 30, // monthly
+            //step:      3600000 * 24 * 30, // monthly
+            limit:     1, // is that a way to make it faster?
             from:      false,
             ack:       false,
             q:         false,
             addID:     false,
-            aggregate: 'minmax'
+            aggregate: 'none'
         })
             .then(values => {
                 if (values.length) {


### PR DESCRIPTION
@GermanBluefox 
I try to fix the following issue #1174 
Therefore i made already some changes where i found issues. But still i am not sure how to solve the issue for gathering the history range. This is the main problem because there the sql selects all data since 1.1.2000 which takes a long time in case the table has a huge number of entries. In my case for some datapoints this affects >10 milion rows. So what i would like to issue is a select statement e.g. "SELECT ts FROM iobroker.ts_number ORDER BY ts ASC LIMIT 1"
Any idea how to handle this with the history adapter?