### PR TITLE
ci: only build pushes on master, avoid double work in PRs

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -8,7 +8,7 @@ name: Test and Release
 on:
   push:
     branches:
-      - '*'
+      - master
     tags:
       # normal versions
       - "v?[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
Without this change, each commit in PRs is built twice - once on push, and once for the pull_request event.