### PR TITLE
Fix: Message filter value doesn't cleared at local storage when clear button is pressed

### DIFF
--- a/src-rx/src/tabs/Logs.js
+++ b/src-rx/src/tabs/Logs.js
@@ -963,7 +963,7 @@ class Logs extends Component {
                                                     this.state.message ? <IconButton
                                                         size="small"
                                                         onClick={e => {
-                                                            this.setState({ message: '' });
+                                                            this.handleMessagechange({ target: { value: ''} });
                                                         }}>
                                                         <ClearIcon />
                                                     </IconButton> : null,


### PR DESCRIPTION
When the clear button at the end of Message filter field pressed, currently only the state is cleared, but local storage clearing is missed.
This fix have to cover this issue