### PR TITLE
add Radio Buttons to value2table 

### DIFF
--- a/src-rx/public/js/adapter-settings.js
+++ b/src-rx/public/js/adapter-settings.js
@@ -1979,7 +1979,10 @@ function values2table(divId, values, onChange, onReady, maxRaw) {
                     type:    $(this).data('type') || 'text',
                     def:     $(this).data('default'),
                     style:   $(this).data('style'),
-                    tdstyle: $(this).data('tdstyle')
+                    tdstyle: $(this).data('tdstyle'),
+                    // add radio Button Id and optional span
+                    radioButtomId: $(this).data('radio'),
+                    radioSpan: $(this).data('span')
                 };
                 if (obj.type === 'checkbox') {
                     if (obj.def === 'false') {
@@ -2047,7 +2050,7 @@ function values2table(divId, values, onChange, onReady, maxRaw) {
                         style = (names[i].style ? names[i].style : 'text-align: right;');
                         line += (v + 1);
                     } else if (names[i].type === 'checkbox') {
-                        line += '<input style="' + (names[i].style || '') + '" class="values-input filled-in" type="checkbox" data-index="' + v + '" data-name="' + names[i].name + '" ' + (values[v][names[i].name] ? 'checked' : '') + '" data-old-value="' + (values[v][names[i].name] === undefined ? '' : values[v][names[i].name]) + '"/>';
+                        line += '<input style="' + (names[i].style || '') + '" class="values-input filled-in" type="checkbox" data-index="' + v + '" data-name="' + names[i].name + '" ' + (values[v][names[i].name] ? 'checked' : '') + ' data-old-value="' + (values[v][names[i].name] === undefined ? '' : values[v][names[i].name]) + '"/>';
                         if (isMaterialize) {
                             line += '<span></span>';
                         }
@@ -2081,6 +2084,8 @@ function values2table(divId, values, onChange, onReady, maxRaw) {
                             line += '<option value="' + p + '" ' + (val.indexOf(p) !== -1 ? ' selected' : '') + '>' + options[p] + '</option>';
                         }
                         line += '</select>';
+                    } else if (names[i].type === 'radio') { // add radio Button in Table
+                        line += '<label><input class="values-input" data-name="' + names[i].name +'" name="' + names[i].radioButtomId + v + '" data-index="' + v + '" type="radio" '+(values[v][names[i].name] ? 'checked' : '')+' data-old-value="' + (values[v][names[i].name] === undefined ? '' : values[v][names[i].name]) + '"/><span>'+(names[i].radioSpan ? names[i].radioSpan : '')+'</span></label>'
                     } else {
                         line += '<input class="values-input" style="' + (names[i].style ? names[i].style : 'width: 100%') + '" type="' + names[i].type + '" data-index="' + v + '" data-name="' + names[i].name + '"/>';
                     }
@@ -2385,6 +2390,8 @@ function table2values(divId) {
                 var name = $input.data('name');
                 if (name) {
                     if ($input.attr('type') === 'checkbox') {
+                        values[j][name] = $input.prop('checked');
+                    } else if ($input.attr('type') === 'radio') { // add radio Button value save
                         values[j][name] = $input.prop('checked');
                     } else {
                         values[j][name] = $input.val();

--- a/src/js/adapter-settings.js
+++ b/src/js/adapter-settings.js
@@ -1979,7 +1979,10 @@ function values2table(divId, values, onChange, onReady, maxRaw) {
                     type:    $(this).data('type') || 'text',
                     def:     $(this).data('default'),
                     style:   $(this).data('style'),
-                    tdstyle: $(this).data('tdstyle')
+                    tdstyle: $(this).data('tdstyle'),
+                    // add radio Button Id and optional span
+                    radioButtomId: $(this).data('radio'),
+                    radioSpan: $(this).data('span')
                 };
                 if (obj.type === 'checkbox') {
                     if (obj.def === 'false') {
@@ -2047,7 +2050,7 @@ function values2table(divId, values, onChange, onReady, maxRaw) {
                         style = (names[i].style ? names[i].style : 'text-align: right;');
                         line += (v + 1);
                     } else if (names[i].type === 'checkbox') {
-                        line += '<input style="' + (names[i].style || '') + '" class="values-input filled-in" type="checkbox" data-index="' + v + '" data-name="' + names[i].name + '" ' + (values[v][names[i].name] ? 'checked' : '') + '" data-old-value="' + (values[v][names[i].name] === undefined ? '' : values[v][names[i].name]) + '"/>';
+                        line += '<input style="' + (names[i].style || '') + '" class="values-input filled-in" type="checkbox" data-index="' + v + '" data-name="' + names[i].name + '" ' + (values[v][names[i].name] ? 'checked' : '') + ' data-old-value="' + (values[v][names[i].name] === undefined ? '' : values[v][names[i].name]) + '"/>';
                         if (isMaterialize) {
                             line += '<span></span>';
                         }
@@ -2081,6 +2084,8 @@ function values2table(divId, values, onChange, onReady, maxRaw) {
                             line += '<option value="' + p + '" ' + (val.indexOf(p) !== -1 ? ' selected' : '') + '>' + options[p] + '</option>';
                         }
                         line += '</select>';
+                    } else if (names[i].type === 'radio') { // add radio Button in Table
+                        line += '<label><input class="values-input" data-name="' + names[i].name +'" name="' + names[i].radioButtomId + v + '" data-index="' + v + '" type="radio" '+(values[v][names[i].name] ? 'checked' : '')+' data-old-value="' + (values[v][names[i].name] === undefined ? '' : values[v][names[i].name]) + '"/><span>'+(names[i].radioSpan ? names[i].radioSpan : '')+'</span></label>'
                     } else {
                         line += '<input class="values-input" style="' + (names[i].style ? names[i].style : 'width: 100%') + '" type="' + names[i].type + '" data-index="' + v + '" data-name="' + names[i].name + '"/>';
                     }
@@ -2385,6 +2390,8 @@ function table2values(divId) {
                 var name = $input.data('name');
                 if (name) {
                     if ($input.attr('type') === 'checkbox') {
+                        values[j][name] = $input.prop('checked');
+                    } else if ($input.attr('type') === 'radio') { // add radio Button value save
                         values[j][name] = $input.prop('checked');
                     } else {
                         values[j][name] = $input.val();


### PR DESCRIPTION
I have added the radio buttons to the table2value / value2table function
the HTML part in the table looks like this without ():
```
<div class="table-values-div">
       <table class="table-values">
               <thead>
               <tr>
                        <th class="header chargerName translate" data-name="TabletName">name</th>
                        <th class="header chargerId translate" data-type='OID' data-name="chargerid">chargerID</th>
                        <th data-name="chargeCycle" data-radio='chargerMode' data-type="radio" data-default="true" class="translate header chargerMode">Charge cycle</th>
                        <th data-name="continuousCurrent" data-radio='chargerMode' data-type="radio" data-default="false" class="translate header chargerMode">Continuous current</th>
                        <th data-name="chargerOff" data-radio='chargerMode' data-type="radio" data-default="false" class="translate header chargerMode">Off</th>
                        <th class="header chargerStart translate" data-default="20" data-type="select" data-name="loadStart" data-options="20/20%;25/25%;30/30%;35/35%;40/40%;45/45%;50/50%">load start</th>
                        <th class="header chargerStop translate" data-default="85" data-type="select" data-name="loadStop" data-options="55/55%;60/60%;65/65%;70/70%;75/75%;80/80%;85/85%;90/90%;95/95%;100/100%">load stop</th>
                        <th class="header Delete translate" data-buttons="delete">delete</th>
              </tr>
              </thead>
       </table>
</div>
```
There must be at least 2 radio buttons for it to work
data-radio='my id'
is important, so that the radio buttons can communicate with each other, this ID must always be the same in the pairs

the result looks like this
![CleanShot 09-03-2022 at 10 48 49](https://user-images.githubusercontent.com/32600934/157423091-d7f988b9-7a8b-4602-9b6c-cc823bfcf78d.png)

a data-span=" here my text" is also possible
