### PR TITLE
Always show the DeleteIcon

### DIFF
--- a/src-rx/src/components/Hosts/HostRow.js
+++ b/src-rx/src/components/Hosts/HostRow.js
@@ -655,12 +655,14 @@ const HostRow = ({
                             </Tooltip> : <div className={classes.emptyButton} />
                         }
                         <Tooltip title={t('Remove')}>
-                            <IconButton disabled={alive || currentHost} title={alive || currentHost ? t('You cannot delete host, when it is alive') : ''} onClick={(e) => {
-                                executeCommandRemove();
-                                e.stopPropagation();
-                            }}>
-                                <DeleteIcon />
-                            </IconButton>
+                            <span>
+                                <IconButton disabled={alive || currentHost} title={alive || currentHost ? t('You cannot delete host, when it is alive') : ''} onClick={(e) => {
+                                    executeCommandRemove();
+                                    e.stopPropagation();
+                                }}>
+                                    <DeleteIcon />
+                                </IconButton>
+                            </span>
                         </Tooltip>
                     </Typography>
                 </div>

--- a/src-rx/src/components/Hosts/HostRow.js
+++ b/src-rx/src/components/Hosts/HostRow.js
@@ -654,14 +654,14 @@ const HostRow = ({
                                 </IconButton>
                             </Tooltip> : <div className={classes.emptyButton} />
                         }
-                        {!alive && !currentHost ? <Tooltip title={t('Remove')}>
-                            <IconButton onClick={(e) => {
+                        <Tooltip title={t('Remove')}>
+                            <IconButton disabled={alive || currentHost} onClick={(e) => {
                                 executeCommandRemove();
                                 e.stopPropagation();
                             }}>
                                 <DeleteIcon />
                             </IconButton>
-                        </Tooltip> : <div className={classes.emptyButton} />}
+                        </Tooltip>
                     </Typography>
                 </div>
             </CardContent>

--- a/src-rx/src/components/Hosts/HostRow.js
+++ b/src-rx/src/components/Hosts/HostRow.js
@@ -655,7 +655,7 @@ const HostRow = ({
                             </Tooltip> : <div className={classes.emptyButton} />
                         }
                         <Tooltip title={t('Remove')}>
-                            <IconButton disabled={alive || currentHost} onClick={(e) => {
+                            <IconButton disabled={alive || currentHost} title={alive || currentHost ? t('You cannot delete host, when it is alive') : ''} onClick={(e) => {
                                 executeCommandRemove();
                                 e.stopPropagation();
                             }}>


### PR DESCRIPTION
#1456 Always show the DeleteIcon, but disabled when the currenthost is or alive.
Background: it is not clear to everyone that a slave can be deleted there, so it is more intuitive.