### PR TITLE
Add tooltip to id 

### DIFF
--- a/src-rx/src/components/ObjectBrowser.jsx
+++ b/src-rx/src/components/ObjectBrowser.jsx
@@ -287,6 +287,18 @@ const styles = theme => ({
     cellIdIconOwn: {
 
     },
+    cellIdTooltip: {
+        fontSize: 14,
+    },
+    cellIdTooltipLink: {
+        color: "#7ec2fd",
+        "&:hover": {
+            color: "#7ec2fd"
+        },
+        "&:visited": {
+            color: "#7ec2fd"
+        }
+    },
     cellCopyButton: {
         width: SMALL_BUTTON_SIZE,
         height: SMALL_BUTTON_SIZE,
@@ -4406,6 +4418,31 @@ class ObjectBrowser extends Component {
 
         const q = checkVisibleObjectType ? Utils.quality2text(this.states[id]?.q || 0).join(', ') : null;
 
+        const getIdFieldTooltip = (data) => {
+            if (data?.obj?.common?.desc && data.obj.common.desc !== '') {
+                let tooltip = '';
+
+                if (typeof data?.obj?.common?.desc === 'object' && data.obj.common.desc[this.props.lang] !== undefined) {
+                    tooltip = data.obj.common.desc[this.props.lang];
+                } else if (typeof data?.obj?.common?.desc === 'object' && data.obj.common.desc['en'] !== undefined) {
+                    tooltip = data.obj.common.desc['en'];
+                } else if (typeof data?.obj?.common?.desc === 'object' && data.obj.common.desc[this.props.lang] === undefined) {
+                    return data.id;
+                } else {
+                    tooltip = data.obj.common.desc;
+                }
+
+                if (tooltip?.startsWith("http")) {
+                    return <a className={Utils.clsx(this.props.classes.cellIdTooltipLink)} href={tooltip}
+                              target="_blank" rel="noreferrer">{tooltip}</a>;
+                }
+
+                return <span className={Utils.clsx(this.props.classes.cellIdTooltip)}>{tooltip}</span>;
+
+            }
+            return data.id;
+        };
+
         return <Grid
             container
             direction="row"
@@ -4453,6 +4490,11 @@ class ObjectBrowser extends Component {
                 </Grid>
                 <Grid
                     item
+                    component={() => (
+                        <Tooltip title={getIdFieldTooltip(item.data)}>
+                            <div>{item.data.name}</div>
+                        </Tooltip>
+                    )}
                     title={id}
                     className={Utils.clsx(classes.cellIdSpan, invertBackground && classes.invertedBackground)}
                     style={{


### PR DESCRIPTION
Purpose of this addition: Show content of common.desc without the need to add a new column in object browser.

This implementation respects the fact that there are objects without the desc field, also only with string and language objects.
To not overload the tooltip by developers with large function/data point description it is possible to use links. The url can be only string or language object, to provide a link for each language. 
The shown link in the tooltip is clickable and opens a new tab. The link has to start with 'http'.

Reference: #886 

---

**Without common.desc (actual this is shown by browser):**  
  
![grafik](https://user-images.githubusercontent.com/16007760/203800355-8bce2978-d4c7-495e-9744-0b5b40634d96.png)
  
---
**With multiple languages:**  
  
![grafik](https://user-images.githubusercontent.com/16007760/203800030-72b5cb00-a882-4030-b893-7f79c9ef859d.png)

---
**With multiple languages but no translation for actual system (ioBroker) language:**  
  
![grafik](https://user-images.githubusercontent.com/16007760/203801628-505765e9-f35b-4285-b497-96a23e9c1565.png)

---
**String only:**  
  
![grafik](https://user-images.githubusercontent.com/16007760/203802540-52bc0a94-4bac-4107-a69c-44cad3c92e22.png)

---
**URLs are clickable:**  
  
![grafik](https://user-images.githubusercontent.com/16007760/203802982-3d97d83f-28ee-4442-8340-63ec51ba71b2.png)
