### PR TITLE
Update SCHEMA.ms - add version info for accordion

### DIFF
--- a/src/src/components/JsonConfigComponent/SCHEMA.md
+++ b/src/src/components/JsonConfigComponent/SCHEMA.md
@@ -190,7 +190,7 @@ Possible types:
     - `showSecondAddAt` - Number of lines from which the second add button at the bottom of the table will be shown. Default 5
     - `clone` - [optional] - if clone button should be shown. If true, the clone button will be shown. If attribute name, this name will be unique.
 
-- `accordion` - accordion with items that could be deleted, added, moved up, moved down
+- `accordion` - accordion with items that could be deleted, added, moved up, moved down (Admin 6.6.0 and newer)
     - `items` - `[{"type": see above, "attr": "name", "default": ""}]` - items can be placed like on a `panel` (xs, sm, md, lg and newLine)
     - `titleAttr` - key of the items list which should be used as name
     - `noDelete` - boolean if delete or add disabled, If `noDelete` is false, add, delete and move up/down should work


### PR DESCRIPTION
It's important that jsonConfig components which have been added later the the initial 5.x release  are marked with the required admin release so that dev can add the correct dependency requirement. This should be done at SCHEMA.ad at least as searching releasenotes and/or commit hisgtory is timeconsuming.