### PR TITLE
Fix color for specific buttons

### DIFF
--- a/src/src/components/ObjectBrowser.jsx
+++ b/src/src/components/ObjectBrowser.jsx
@@ -1595,10 +1595,10 @@ function formatValue(options) {
  * @return {{color: (string)}}
  */
 function getValueStyle(options) {
-    const { state, isExpertMode, obj } = options;
+    const { state, isExpertMode, isButton } = options;
     let color = state?.ack ? (state.q ? '#ffa500' : '') : '#ff2222c9';
 
-    if (!isExpertMode && obj.common.role === 'button') {
+    if (!isExpertMode && isButton) {
         color = '';
     }
 
@@ -4345,7 +4345,7 @@ class ObjectBrowser extends Component {
             ];
         }
 
-        info.style = getValueStyle({ isExpertMode: this.state.filter.expertMode, state, obj });
+        info.style = getValueStyle({ state, isExpertMode: this.state.filter.expertMode, isButton: item.data.button });
 
         let val = info.valText;
         if (!this.state.filter.expertMode && item.data.button) {

--- a/src/src/components/ObjectBrowser.jsx
+++ b/src/src/components/ObjectBrowser.jsx
@@ -1586,7 +1586,7 @@ function formatValue(options) {
     };
 }
 
-/** @typedef {{ state: ioBroker.State, isExpertMode: boolean, obj: ioBroker.StateObject }} GetValueStyleOptions */
+/** @typedef {{ state: ioBroker.State, isExpertMode: boolean, isButton: boolean }} GetValueStyleOptions */
 
 /**
  * Get css style for given state value


### PR DESCRIPTION
This is a follow-up to #1988, making it work for all kinds of buttons (e.g. `button.stop`).