### PR TITLE
Update package.json - require node 16.4.0 - fixes #2044

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ldittmar <iobroker@lmdsoft.de>"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.4.0"
   },
   "homepage": "https://github.com/ioBroker/ioBroker.admin",
   "repository": {


### PR DESCRIPTION
Admin uses now adapter-core 3.x.x. This known to create problem when trying to install with npm6 (included with node14).
As node 14 is obsolete anyway, admin should require node 16 to ensure that the installation does not create issues at older systems still running node 14.

This PR changes engines entry to require node 16.4.0 or newer