### PR TITLE
JSON config component 'port' does no longer mark port as occupied if …

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ The icons may not be reused in other projects without the proper flaticon licens
 	### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (foxriver76) JSON config component `port` does no longer mark port as occupied if it is only occupied on another host
+
 ### 6.10.4 (2023-09-25)
 * (foxriver76) fixed parsing `jsonConfig`
 

--- a/src/src/components/JsonConfigComponent/ConfigPort.tsx
+++ b/src/src/components/JsonConfigComponent/ConfigPort.tsx
@@ -58,11 +58,14 @@ class ConfigPort extends ConfigGeneric<ConfigPortProps, ConfigPortState> {
         const instances: ioBroker.InstanceObject[] = await this.props.socket.getAdapterInstances();
 
         const ownId = `system.adapter.${this.props.adapterName}.${this.props.instance}`;
+        const instanceObj: ioBroker.InstanceObject = await this.props.socket.getObject(ownId);
+        const ownHostname = instanceObj?.common.host;
+
         const ports: Port[] = [];
         instances
             .forEach(instance => {
-                // ignore own instance
-                if (instance._id === ownId) {
+                // ignore own instance and instances on other host
+                if (instance._id === ownId || instance.common.host !== ownHostname) {
                     return;
                 }
                 // if let's encrypt is enabled and update is enabled, then add port to check


### PR DESCRIPTION
…it is only occupied on another host