### PR TITLE
#2178 new objects only after reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The icons may not be reused in other projects without the proper flaticon licens
 
 ### **WORK IN PROGRESS**
 * (foxriver76) optimzied the notificaiton popup (auto-extend first entry per category, respect line breaks, respect severity for icons)
+* (theimo1221) #2178 Stabilize onObjectChange handling during creation of new objects in WebUi, to directly show new element.
 
 ### 6.12.0 (2023-10-24)
 * (foxriver76) fixed issue when updating news in backend

--- a/src/src/components/ObjectBrowser.jsx
+++ b/src/src/components/ObjectBrowser.jsx
@@ -10,6 +10,7 @@ import React, { Component, createRef } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@mui/styles';
 import SVG from 'react-inlinesvg';
+import _ from 'lodash';
 
 import {
     IconButton,
@@ -101,7 +102,6 @@ import Utils from './Utils'; // @iobroker/adapter-react-v5/Components/Utils
 import TabContainer from './TabContainer';
 import TabContent from './TabContent';
 import TabHeader from './TabHeader';
-import _ from 'lodash';
 
 const ICON_SIZE = 24;
 const ROW_HEIGHT = 32;

--- a/src/src/components/ObjectBrowser.jsx
+++ b/src/src/components/ObjectBrowser.jsx
@@ -2371,9 +2371,9 @@ class ObjectBrowser extends Component {
     async componentDidMount() {
         await this.loadAllObjects(!objectsAlreadyLoaded);
         if (this.props.objectsWorker) {
-            this.props.objectsWorker.registerHandler(this.onObjectChange);
+            this.props.objectsWorker.registerHandler(this.onObjectChange.bind(this));
         } else {
-            this.props.socket.subscribeObject('*', this.onObjectChange);
+            this.props.socket.subscribeObject('*', this.onObjectChange.bind(this));
         }
 
         objectsAlreadyLoaded = true;
@@ -2390,9 +2390,9 @@ class ObjectBrowser extends Component {
         window.removeEventListener('contextmenu', this.onContextMenu, true);
 
         if (this.props.objectsWorker) {
-            this.props.objectsWorker.unregisterHandler(this.onObjectChange, true);
+            this.props.objectsWorker.unregisterHandler(this.onObjectChange.bind(this), true);
         } else {
-            this.props.socket.unsubscribeObject('*', this.onObjectChange);
+            this.props.socket.unsubscribeObject('*', this.onObjectChange.bind(this));
         }
 
         // remove all subscribes

--- a/src/src/components/ObjectBrowser.jsx
+++ b/src/src/components/ObjectBrowser.jsx
@@ -3007,6 +3007,8 @@ class ObjectBrowser extends Component {
                     } else {
                         delete this.objects[event.id];
                     }
+                } else if (event.obj) {
+                    this.objects[event.id] = event.obj;
                 }
             });
         } else {
@@ -3031,6 +3033,8 @@ class ObjectBrowser extends Component {
                 } else {
                     delete this.objects[id];
                 }
+            } else if (obj) {
+                this.objects[id] = obj;
             }
         }
 


### PR DESCRIPTION
Hello @foxriver76,

please review these changes carefully, which should hopefully resolve #2178.
In my local test enviroment, I was able to add new objects. Personally I still can't explain why this should have worked in 6.0.11 and stopped working in 6.0.12. 
Somehow `this.objects` must have gotten the newly added object outside of `onObjectChange` in the past but I couldn't pinpoint that.

Best regards

Thiemo
