### PR TITLE
redirect correctly when exiting json config with unsaved changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ The icons may not be reused in other projects without the proper flaticon licens
 	### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (foxriver76) redirect correctly when exiting json config with unsaved changes
+
 ### 6.13.15 (2024-01-01)
 * (foxriver76) fixed scrolling of Select ID dialogs
 

--- a/packages/jsonConfig/src/JsonConfig.tsx
+++ b/packages/jsonConfig/src/JsonConfig.tsx
@@ -391,7 +391,7 @@ class JsonConfig extends Router<JsonConfigProps, JsonConfigState> {
             ok={I18n.t('ra_Discard')}
             cancel={I18n.t('ra_Cancel')}
             onClose={isYes =>
-                this.setState({ confirmDialog: false }, () => isYes && Router.doNavigate())}
+                this.setState({ confirmDialog: false }, () => isYes && Router.doNavigate(null))}
         />;
     }
 


### PR DESCRIPTION
- closes #2287