### PR TITLE
Use jsonConfig Schema locates at ioBroker.admin repository

### DIFF
--- a/packages/admin/src/lib/web.ts
+++ b/packages/admin/src/lib/web.ts
@@ -196,7 +196,8 @@ class Web {
 
     /** URL to the JSON config schema */
     private readonly JSON_CONFIG_SCHEMA_URL =
-        'https://raw.githubusercontent.com/ioBroker/adapter-react-v5/main/schemas/jsonConfig.json';
+        'https://raw.githubusercontent.com/ioBroker/ioBroker.admin/blob/master/packages/jsonConfig/schemas/jsonConfig.json';
+        // 'https://raw.githubusercontent.com/ioBroker/adapter-react-v5/main/schemas/jsonConfig.json';
 
     private store: Store | null = null;
     private indexHTML: string;


### PR DESCRIPTION
According to @GermanBluefox admin should now use schema located at ioBroker.admin for testing validity of ijsonConfig file.