### PR TITLE
Add dependency to @module-federation/runtime to pacakge jsonConfig

### DIFF
--- a/packages/jsonConfig/package.json
+++ b/packages/jsonConfig/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@iobroker/adapter-react-v5": "file:../adapter-react-v5",
+        "@module-federation/runtime": "^0.11.1",
         "@mui/x-date-pickers": "^7.27.1",
         "crypto-js": "^4.2.0",
         "json5": "^2.2.3",


### PR DESCRIPTION
Pacakge jsonConfig uses package @module-federation/runtime but did not yet declare the dependency at pacakge.json.

fixes https://github.com/ioBroker/ioBroker.admin/issues/3016

@GermanBluefox - please review if adding the dependency is a valid solution