### PR TITLE
Update web.ts - log location of json schema used

### DIFF
--- a/packages/admin/src/lib/web.ts
+++ b/packages/admin/src/lib/web.ts
@@ -375,6 +375,7 @@ class Web {
         let schema: Record<string, any> | null = null;
 
         try {
+            this.adapter.log.debug(`retrieving json schema from ${`this.JSON_CONFIG_SCHEMA_URL`);
             const schemaRes = await axios.get(this.JSON_CONFIG_SCHEMA_URL);
             schema = schemaRes.data as Record<string, any>;
         } catch (e) {

--- a/packages/admin/src/lib/web.ts
+++ b/packages/admin/src/lib/web.ts
@@ -375,7 +375,7 @@ class Web {
         let schema: Record<string, any> | null = null;
 
         try {
-            this.adapter.log.debug(`retrieving json schema from ${`this.JSON_CONFIG_SCHEMA_URL}`);
+            this.adapter.log.debug(`retrieving json schema from ${this.JSON_CONFIG_SCHEMA_URL}`);
             const schemaRes = await axios.get(this.JSON_CONFIG_SCHEMA_URL);
             schema = schemaRes.data as Record<string, any>;
         } catch (e) {

--- a/packages/admin/src/lib/web.ts
+++ b/packages/admin/src/lib/web.ts
@@ -375,7 +375,7 @@ class Web {
         let schema: Record<string, any> | null = null;
 
         try {
-            this.adapter.log.debug(`retrieving json schema from ${`this.JSON_CONFIG_SCHEMA_URL`);
+            this.adapter.log.debug(`retrieving json schema from ${`this.JSON_CONFIG_SCHEMA_URL}`);
             const schemaRes = await axios.get(this.JSON_CONFIG_SCHEMA_URL);
             schema = schemaRes.data as Record<string, any>;
         } catch (e) {


### PR DESCRIPTION
This PR adds a debug log to list the location of the used jsonConfig schema.

(As I am currently investigating why admin logs schema errors which vsCode does not log although they seem to use the same schema it would have been fine to see which schema file admin really loads.)