### PR TITLE
Update README.md - extend description of staticText

### DIFF
--- a/packages/jsonConfig/README.md
+++ b/packages/jsonConfig/README.md
@@ -665,6 +665,8 @@ static text like description
 | `label`  | multi-language text |
 | `text`   | same as label       |
 
+exactly one of `label` or `text` must be specified - not both
+
 ### `staticLink`
 
 | Property  | Description                                                                                                                                                                                                                                                                     |


### PR DESCRIPTION
Object staticTests allows only test or label attribute - at least according to schema definition.

This info was not provided at README.md and has been added.

@GermanBluefox please verify if the statement is correct, if really both attributes might be added (don't know why this should be the case) please correct scheme instead.