### PR TITLE
Add missing jsonEditor default string property in jsonconfig schema

### DIFF
--- a/packages/jsonConfig/schemas/jsonConfig.json
+++ b/packages/jsonConfig/schemas/jsonConfig.json
@@ -1458,6 +1458,10 @@
                     "type": "boolean",
                     "description": "Open the editor in read-only mode - editor can be opened but content cannot be modified"
                 },
+                "default": {
+                    "type": "string",
+                    "description": "Default content for JSON Editor"
+                },
                 "label": true,
                 "type": true,
                 "defaultSendTo": true,


### PR DESCRIPTION
the "default" property for jsonEditor in jsonconfig.json is implemented and working fine, I use it in TipperLink adapter. But it's definition is missing in schema for jsonconfig.json