### PR TITLE
fix: handle jsonCustom validation inline

### DIFF
--- a/src-admin/src/components/Object/ObjectCustomDialog.tsx
+++ b/src-admin/src/components/Object/ObjectCustomDialog.tsx
@@ -65,6 +65,7 @@ interface ObjectCustomDialogProps {
 
 interface ObjectCustomDialogState {
     hasChanges: boolean;
+    validationError: boolean;
     currentTab: number;
     confirmDialog: boolean;
     mobile: boolean;
@@ -100,6 +101,7 @@ class ObjectCustomDialog extends MobileDialog<ObjectCustomDialogProps, ObjectCus
 
         this.state = {
             hasChanges: false,
+            validationError: false,
             currentTab,
             confirmDialog: false,
             mobile: MobileDialog.isMobile(),
@@ -167,6 +169,7 @@ class ObjectCustomDialog extends MobileDialog<ObjectCustomDialogProps, ObjectCus
                 customsInstances={this.props.customsInstances}
                 objects={this.props.objects}
                 onProgress={(progressRunning: boolean) => this.setState({ progressRunning })}
+                onError={(validationError = false) => this.setState({ validationError })}
                 reportChangedIds={this.props.reportChangedIds}
                 onChange={(hasChanges: boolean, update: boolean) => {
                     this.setState({ hasChanges }, () => {
@@ -335,7 +338,9 @@ class ObjectCustomDialog extends MobileDialog<ObjectCustomDialogProps, ObjectCus
                             id="object-custom-dialog-save"
                             variant="contained"
                             color="primary"
-                            disabled={!this.state.hasChanges || this.state.progressRunning}
+                            disabled={
+                                !this.state.hasChanges || this.state.progressRunning || this.state.validationError
+                            }
                             onClick={() => this.saveFunc && this.saveFunc()}
                         >
                             {this.getButtonTitle(<SaveIcon />, this.props.t('Save'))}
@@ -346,7 +351,9 @@ class ObjectCustomDialog extends MobileDialog<ObjectCustomDialogProps, ObjectCus
                             id="object-custom-dialog-save-close"
                             variant="contained"
                             color="primary"
-                            disabled={!this.state.hasChanges || this.state.progressRunning}
+                            disabled={
+                                !this.state.hasChanges || this.state.progressRunning || this.state.validationError
+                            }
                             onClick={() => {
                                 if (this.saveFunc) {
                                     this.saveFunc(error => !error && this.onClose());

--- a/src-admin/src/components/Object/ObjectCustomEditor.tsx
+++ b/src-admin/src/components/Object/ObjectCustomEditor.tsx
@@ -15,7 +15,7 @@ import {
 // Icons
 import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
 
-import { DialogError, DialogConfirm, type IobTheme } from '@iobroker/gui-components';
+import { DialogConfirm, type IobTheme } from '@iobroker/gui-components';
 
 import { ConfigGeneric, JsonConfigComponent, type ConfigItemPanel } from '@iobroker/json-config';
 import AdminUtils from '@/helpers/AdminUtils';
@@ -118,7 +118,6 @@ interface ObjectCustomEditorState {
     maxOids: number;
     confirmed: boolean;
     showConfirmation: boolean;
-    error?: boolean;
     systemConfig?: ioBroker.SystemConfigObject;
 }
 
@@ -138,6 +137,7 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
 
     /** Cached per-instance filter functions: returns true if objectId is allowed */
     private statesFilterFunctions: Record<string, (objectId: string) => boolean> = {};
+    private validationErrors = new Set<string>();
     private cb?: () => void;
     private cachedNewValues?: Record<string, any>;
 
@@ -198,6 +198,20 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
     componentWillUnmount(): void {
         if (this.props.registerSaveFunc) {
             this.props.registerSaveFunc();
+        }
+        this.props.onError?.(false);
+    }
+
+    private setValidationError(instance: string, error: boolean): void {
+        const hadErrors = this.validationErrors.size > 0;
+        if (error) {
+            this.validationErrors.add(instance);
+        } else {
+            this.validationErrors.delete(instance);
+        }
+        const hasErrors = this.validationErrors.size > 0;
+        if (hadErrors !== hasErrors) {
+            this.props.onError?.(hasErrors);
         }
     }
 
@@ -303,6 +317,13 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
                 let jsonSchema: ConfigItemPanel;
                 try {
                     jsonSchema = JSON5.parse(jsonText);
+                    if (jsonSchema.validatorNoSaveOnError) {
+                        Object.values(ObjectCustomEditor.flattenItems(jsonSchema.items)).forEach(item => {
+                            if (item.validator && item.validatorNoSaveOnError === undefined) {
+                                item.validatorNoSaveOnError = true;
+                            }
+                        });
+                    }
                     this.jsonConfigs[adapter] = this.jsonConfigs[adapter] || {};
                     this.jsonConfigs[adapter].json = jsonSchema;
                 } catch (e) {
@@ -686,9 +707,10 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
                                     onChange={e => {
                                         this.cachedNewValues = this.cachedNewValues || this.state.newValues;
                                         const newValues = AdminUtils.deepClone(this.cachedNewValues);
+                                        const willEnable = !!isIndeterminate || e.target.checked;
 
                                         newValues[instance] = newValues[instance] || {};
-                                        if (isIndeterminate || e.target.checked) {
+                                        if (willEnable) {
                                             newValues[instance].enabled = true;
                                         } else if (enabled) {
                                             if (this.commonConfig[instance].enabled) {
@@ -698,6 +720,9 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
                                             }
                                         } else {
                                             delete newValues[instance];
+                                        }
+                                        if (!willEnable) {
+                                            this.setValidationError(instance, false);
                                         }
                                         this.cachedNewValues = newValues;
                                         this.setState({ newValues, hasChanges: this.isChanged(newValues) }, () => {
@@ -729,9 +754,7 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
                                 data={data}
                                 isFloatComma={this.props.systemConfig.common.isFloatComma}
                                 dateFormat={this.props.systemConfig.common.dateFormat}
-                                onError={(error: boolean) =>
-                                    this.setState({ error }, () => this.props.onError?.(error))
-                                }
+                                onError={(error: boolean) => this.setValidationError(instance, error)}
                                 onValueChange={(attr: string, value: any) => {
                                     this.cachedNewValues = this.cachedNewValues || this.state.newValues;
                                     console.log(`${attr} => ${value}`);
@@ -763,18 +786,6 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
                     </div>
                 </AccordionDetails>
             </Accordion>
-        );
-    }
-
-    renderErrorMessage(): JSX.Element {
-        return (
-            !!this.state.error && (
-                <DialogError
-                    title={this.props.t('Error')}
-                    text={this.state.error ? 'Error' : ''}
-                    onClose={() => this.setState({ error: false })}
-                />
-            )
         );
     }
 
@@ -1006,7 +1017,6 @@ export default class ObjectCustomEditor extends Component<ObjectCustomEditorProp
                             return null;
                         })}
                 </div>
-                {this.renderErrorMessage()}
                 {this.renderConfirmationDialog()}
             </Paper>
         );


### PR DESCRIPTION
# Fix inline validation in jsonCustom dialogs

## Summary

- Show `jsonCustom` validation errors inline without opening a generic error dialog.
- Disable **Save** and **Save & close** while blocking validation errors are present.
- Aggregate validation errors when multiple custom adapter configurations are displayed.
- Support a backward-compatible panel-level opt-in for blocking validation.

## Backward compatibility

Adapters can set `validatorNoSaveOnError: true` on the root panel of their `jsonCustom` schema. Admin cascades this setting to child items that have a validator and do not define their own `validatorNoSaveOnError` value.

Older Admin versions ignore the setting on the root panel. They continue to show inline field validation without triggering their generic error dialog, while newer Admin versions additionally prevent invalid data from being saved. Existing per-field `validatorNoSaveOnError` settings remain supported and an explicit per-field value takes precedence.

## Test coverage

- `npm run check-ts`
- `npm run lint` (no errors; three unrelated pre-existing warnings)
- `npm run build`
- Browser-tested against a locally installed Admin 7.8.23 build:
  - invalid fields are highlighted inline
  - **Save** and **Save & close** are disabled while invalid
  - both buttons are enabled after the fields become valid
  - no additional error dialog is opened
  - no browser page errors occur

Closes #3580
