### PR TITLE
fix admin behind reverse proxy sub-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,107 +80,7 @@ walks you through three steps:
 
 ## Reverse proxy
 
-Please be sure that you forward not only the http/https requests, but the web-socket traffic too. It is essential for communication.
-
-From version 6.1.0 you have the possibility to tune the intro page for usage with reverse proxy.
-
-### Example
-
-Your `ioBroker.admin` runs on port 8081 behind reverse proxy with domain `iobroker.mydomain.com` under path `/ioBrokerAdmin/`.
-And you set up e.g., nginx to forward the requests to the `http://local-iobroker.IP:8081`.
-
-The same is with your web instance: `https://iobroker.mydomain.com/ioBrokerWeb/ => http://local-iobroker.IP:8082`.
-And with rest-api instance: `https://iobroker.mydomain.com/ioBrokerAPI/ => http://local-iobroker.IP:8093`.
-
-You can add the following lines into the Reverse Proxy tab to let the Intro tab run behind the reverse proxy properly:
-
-| Global path       | Instance      | Instance path behind proxy |
-|-------------------|---------------|----------------------------|
-| `/ioBrokerAdmin/` | `web.0`       | `/ioBrokerWeb/`            |
-|                   | `rest-api.0`  | `/ioBrokerAPI/`            |
-|                   | `admin.0`     | `/ioBrokerAdmin/`          |
-|                   | `eventlist.0` | `/ioBrokerWeb/eventlist/`  |
-
-So all links of instances that use web server, like `eventlist`, `vis`, `material` and so on will use `https://iobroker.mydomain.com/ioBrokerWeb/` path
-
-### Extended reverse proxy example (with screenshots)
-
-Below is a more complete example showing how a reverse proxy (e.g. Nginx Proxy Manager) can be configured and how the Admin UI resolves links after mapping.
-
-> NOTE: At the moment the admin UI itself still needs to be effectively served from the web root `/` of the host. login and other hardcoded urls do not yet respect another base path (see limitation discussion here: https://github.com/ioBroker/ioBroker.admin/issues/1660#issuecomment-2360056439).
-
-#### 1. Base host / root mapping
-
-Map the public root (or a dedicated host like `https://iobroker.example.com/`) directly to your Admin instance (default port 8081):
-
-<img src="assets/revproxy_nginxpm_root.png" alt="Nginx Proxy Manager: root mapping to admin" width="640" />
-
-#### 2. Custom locations for other services
-
-Add additional custom locations for web / REST / other adapter frontends. Each location forwards to the respective local port (e.g. `web.0` on 8082, rest-api.0 on 8093):
-
-<img src="assets/revproxy_nginxpm_customlocations.png" alt="Nginx Proxy Manager: custom locations" width="640" />
-
-Example custom locations (Nginx style):
-```
-/web/  => http://LOCAL_IOBROKER_IP:8082/
-/welcome/  => http://LOCAL_IOBROKER_IP:PORT_CONFIGURED_IN_WELCOME_INSTANCE_SETTINGS/
-/esphome/  => http://LOCAL_IOBROKER_IP:6052/
-```
-If you have views imported from vis into vis-2, it is possible images / ... are still used from the old vis path. 
-In this case (or to be on the safe side - just also configuring them should not break other things) you probably also want to add these locations (NOTE: no trailing / here!):
-```
-/vis.0 => http://LOCAL_IOBROKER_IP:8082
-/vis/widgets => http://LOCAL_IOBROKER_IP:8082
-/vis-2/widgets => http://LOCAL_IOBROKER_IP:8082
-/icons-mfd-svg => http://LOCAL_IOBROKER_IP:8082
-/icons-material-png => http://LOCAL_IOBROKER_IP:8082
-```
-(Adjust paths/ports for your environment.)
-
-#### 3. Configure mappings in the Admin Reverse Proxy tab
-
-Enter the same paths so that Intro / Instances pages rewrite adapter links correctly. Also add paths for all adapters running as web extension (like rest-api, ...). Obviously, you only need to configure what you are actually using. Here are some examples:
-
-| Global path | Instance     | Instance path behind proxy |
-|-------------|--------------|----------------------------|
-| `/`         | `web.0`      | `/web/`                    |
-|             | `welcome.0`  | `/welcome/`                |
-|             | `rest-api.0` | `/web/rest-api/`           |
-|             | `esphome.0`  | `/esphome/`                |
-
-> If you keep Admin on `/` you usually do not need to list `admin.0`, but adding it does not hurt and can make intent explicit.
-
-After saving, the Intro screen rewrites links so that all web‑served adapters open under the correct prefixed paths:
-
-<img src="assets/revproxy_admin.png" alt="Admin Intro page after reverse proxy mapping" width="640" />
-
-#### 4. Limitations & compatibility
-
-* Admin root requirement: As stated above, full relocation of Admin itself under a sub‑path (e.g. `/admin/`) is not yet supported.
-* Adapter path awareness: Not every adapter UI is currently path‑aware. While generic `localLink` rewriting covers many cases, some UIs still assume they are hosted at the domain root. Known examples:
-  * `vis` (classic) – NOT fully working behind a sub‑path today.
-  * `vis-2` – generally more path tolerant, but custom widgets or legacy resources may still use absolute paths.
-  * Any adapter serving hard‑coded absolute URLs (starting with `/`) may need manual fixes until updated upstream. Please open issues in the respective adapter repositories to notify maintainers.
-* Mixed content: If you terminate TLS at the proxy (HTTPS) but contact adapters over HTTP internally, make sure all external links are rewritten to HTTPS to avoid browser mixed-content blocks.
-* WebSocket forwarding: Ensure `Upgrade` and `Connection` headers are passed through. In Nginx, this typically means adding:
-```
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection "upgrade";
-```
-(or checking the websocket support box, if using proxy manager)
-* Trailing slashes: Often a trailing slash in the mapped path (e.g. `/web/`) and location are required for path unaware adapters. 
-Then nginx does path rewriting, which makes most cases like the welcome adapter above work, because it only sees a / path -> correctly serves its index.html.
-
-#### 5. Quick troubleshooting checklist
-
-| Symptom                            | Likely cause                         | Action                                                                                                                                                       |
-|------------------------------------|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Blank or partial Admin UI          | Admin mounted under sub‑path only    | Keep Admin at `/` (see limitation)                                                                                                                           |
-| Adapter link opens wrong host/port | Missing entry in Reverse Proxy tab   | Add mapping row and save                                                                                                                                     |
-| 404 for adapter JS/CSS             | Missing trailing slash in location   | Add trailing slash to location and mapping                                                                                                                   |
-| WebSocket errors in console        | Proxy not forwarding upgrade headers | Add `proxy_set_header Upgrade` / `Connection` headers                                                                                                        |
-| other (loading) issue              | Adapter not path‑aware               | Keep on root or wait for adapter update. Please open an issue in the adapters repository so the maintainers are aware about it and the issue can be tracked. |
+The reverse proxy documentation can be found at [Reverse proxy](REVERSE_PROXY.md).
 
 ## Used icons
 
@@ -196,6 +96,9 @@ The icons may not be reused in other projects without the proper flaticon licens
     Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+- (SimonFischer04) Admin can now run behind a reverse-proxy sub-path (e.g. `/admin/`)
+
 ### 8.0.4 (2026-08-09)
 - (@GermanBluefox) Better handlling of autocompleteSendTo JsonConfig components
 

--- a/REVERSE_PROXY.md
+++ b/REVERSE_PROXY.md
@@ -157,3 +157,51 @@ The socket client will then correctly try to connect to e.g. `http://iobroker-te
 
 Why not just use the root (admins) socket (e.g. `ws://iobroker-test.revproxy.home.arpa/?sid=1780827297411&name=echarts-show`)?: 
 Admin needs authentication and web usually not, so you would have to be logged in to admin for your views (served by web!) to load. Also, when not using a proxy setup, it would also use the web adapters socket (request to :8082/?sid=...) - so also using the web adapters socket for reverse proxy setup is the correct approach.
+
+## Complete nginx configuration
+
+Same layout as the table above: Admin at `/admin/`, web at `/web/`, esphome at `/esphome/`, optional welcome at `/`. The trailing slash on `proxy_pass` strips the location prefix so Admin sees `/` (and `:8081/admin/` still works).
+
+```nginx
+# Redirect HTTP → HTTPS
+server {
+    listen 80;
+    listen [::]:80;
+    server_name iobroker.example.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name iobroker.example.com;
+
+    ssl_certificate     /etc/nginx/ssl/iobroker.example.com.crt;
+    ssl_certificate_key /etc/nginx/ssl/iobroker.example.com.key;
+
+    # Optional: landing page (welcome adapter) at the host root
+    location / {
+        proxy_pass http://LOCAL_IOBROKER_IP:1234/;
+    }
+
+    location /admin/ {
+        proxy_pass http://LOCAL_IOBROKER_IP:8081/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+    }
+
+    location /web/ {
+        proxy_pass http://LOCAL_IOBROKER_IP:8082/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $http_connection;
+    }
+
+    location /esphome/ {
+        proxy_pass http://LOCAL_IOBROKER_IP:6052/;
+    }
+}
+```
+
+Replace `LOCAL_IOBROKER_IP`, the welcome port, and the certificate paths. Add further `location` blocks the same way.

--- a/REVERSE_PROXY.md
+++ b/REVERSE_PROXY.md
@@ -27,13 +27,15 @@ So all links of instances that use web server, like `eventlist`, `vis`, `materia
 
 Below is a more complete example showing how a reverse proxy (e.g. Nginx Proxy Manager) can be configured and how the Admin UI resolves links after mapping.
 
-> NOTE: At the moment the admin UI itself still needs to be effectively served from the web root `/` of the host. login and other hardcoded urls do not yet respect another base path (see limitation discussion here: https://github.com/ioBroker/ioBroker.admin/issues/1660#issuecomment-2360056439).
+Admin can run at the host root `/` or under a sub-path such as `/admin/`. List `admin.0` in the table whenever Admin is not at `/`.
 
 ### 1. Base host / root mapping
 
-Map the public root (or a dedicated host like `https://iobroker.example.com/`) directly to your Admin instance (default port 8081):
+OPTIONAL: To keep Admin at the public root, map the host (e.g. `https://iobroker.example.com/`) directly to your Admin instance (default port 8081):
 
 <img src="assets/revproxy_nginxpm_root.png" alt="Nginx Proxy Manager: root mapping to admin" width="640" />
+
+As admin can now also be on a sub-path like `/admin/` you can for example also proxy the root / path to the web or [welcome](https://github.com/ioBroker/ioBroker.welcome) adapter to get a nice dashboard from where you can quickly navigate to admin/web/... when visiting f.e. `iobroker.example.com`.
 
 ### 2. Custom locations for other services
 
@@ -48,8 +50,16 @@ location /esphome/  => http://LOCAL_IOBROKER_IP:6052/
 ```
 (Adjust paths/ports for your environment.)
 
-Configuring the location for web is a bit more complicated, as it also needs websocket support. To do this in nginx proxy manager, you need to add the following custom nginx configuration.
+Configuring the location for admin and web is a bit more complicated, as they also need websocket support. To do this in nginx proxy manager, you need to add the following custom nginx configuration.
 ```
+location /admin/ {
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection $http_connection;
+  proxy_http_version 1.1;
+
+  proxy_pass http://LOCAL_IOBROKER_IP:8081/;
+}
+
 location /web/ {
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection $http_connection;
@@ -66,12 +76,13 @@ Enter the same paths so that Intro / Instances pages rewrite adapter links corre
 
 | Global path | Instance     | Instance path behind proxy |
 |-------------|--------------|----------------------------|
-| `/`         | `web.0`      | `/web/`                    |
+| `/`         | `admin.0`    | `/admin/`                  |
+|             | `web.0`      | `/web/`                    |
 |             | `welcome.0`  | `/welcome/`                |
 |             | `esphome.0`  | `/esphome/`                |
 |             | `rest-api.0` | `/web/rest-api/api-doc/`   |
 
-> If you keep Admin on `/` you usually do not need to list `admin.0`, but adding it does not hurt and can make intent explicit.
+> If you keep Admin on `/` you usually do not need to list `admin.0`.
 
 After saving, the Intro screen rewrites links so that all web‑served adapters open under the correct prefixed paths:
 
@@ -79,29 +90,29 @@ After saving, the Intro screen rewrites links so that all web‑served adapters 
 
 ### 4. Limitations & compatibility
 
-* Admin root requirement: As stated above, full relocation of Admin itself under a sub‑path (e.g. `/admin/`) is not yet supported.
 * Adapter path awareness: Not every adapter UI is currently path‑aware. While generic `localLink` rewriting covers many cases, some UIs still assume they are hosted at the domain root. See the [Tested adapters](#tested-adapters) table below. Any adapter serving hard‑coded absolute URLs (starting with `/`) may need manual fixes until updated upstream.
 
 #### Tested adapters
 
-The following adapters have been tested behind a path‑prefixed reverse proxy (Admin at host root `/`, other services under sub‑paths such as `/web/`). Not being listed here does not necessarily mean an adapter is incompatible, just that it has not been explicitly tested yet. At least everything running as a web extension and using standard iobroker tooling - but also others - should mostly just work.
+The following adapters have been tested behind a path‑prefixed reverse proxy (Admin at host root `/` or under a configured sub-path, other services under sub‑paths such as `/web/`). Not being listed here does not necessarily mean an adapter is incompatible, just that it has not been explicitly tested yet. At least everything running as a web extension and using standard iobroker tooling - but also others - should mostly just work.
 
 Contributions welcome via PR.
 
 ✅ works · ⚠️ partial / with limitations · ❌ does not work
 
-| Adapter                                                 | Works | Minimum versions             | Notes                                                                                                                                                             |
-|---------------------------------------------------------|:-----:|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [admin](https://github.com/ioBroker/ioBroker.admin)     | ⚠️ | admin ≥ 7.7.18               | Only when served at host root `/`; sub‑path relocation (e.g. `/admin/`) not supported                                                                             |
-| [echarts](https://github.com/ioBroker/ioBroker.echarts) | ✅ | web ≥ 8.3.0, echarts ≥ 3.2.0 |                                                                                                                                                                   |
-| [esphome](https://github.com/DrozmotiX/ioBroker.esphome) | ✅ | —                            | Shown in extended example; dedicated proxy path (e.g. `/esphome/`)                                                                                                |
-| [rest-api](https://github.com/ioBroker/ioBroker.rest-api) | ⚠️ | —                            | Swagger UI 'Try it out' does not respect sub-path / tries to call root \<host\>/rest-api/... Manual call to correct  \<host\>/web/rest-api/...  url works fine.   |
-| [vis](https://github.com/ioBroker/ioBroker.vis)         | ❌ | —                            | Not path‑aware; UI broken behind a sub‑path                                                                                                                       |
-| [vis-2](https://github.com/ioBroker/ioBroker.vis-2)     | ⚠️ | —                            | Generally path tolerant; custom widgets or legacy resources may use absolute paths. Also see *1                                                                   |
-| [web](https://github.com/ioBroker/ioBroker.web)         | ✅ | —                            | Base for web‑hosted adapter UIs; proxy under e.g. `/web/`. Important: Also requires correct configuration of web adapter: see bellow "6. Configuring Web Adapter" |
-| [welcome](https://github.com/ioBroker/ioBroker.welcome) | ✅ | —                            |                                                                                                                                                                   |
+| Adapter                                                 | Works | Minimum versions             | Notes                                                                                                                                                                            |
+|---------------------------------------------------------|:-----:|------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [admin](https://github.com/ioBroker/ioBroker.admin)     | ✅ | next admin release           |                                                                                                                                                                                  |
+| [echarts](https://github.com/ioBroker/ioBroker.echarts) | ✅ | web ≥ 8.3.0, echarts ≥ 3.2.0 |                                                                                                                                                                                  |
+| [esphome](https://github.com/DrozmotiX/ioBroker.esphome) | ✅ | —                            | Shown in extended example; dedicated proxy path (e.g. `/esphome/`)                                                                                                               |
+| [rest-api](https://github.com/ioBroker/ioBroker.rest-api) | ⚠️ | —                            | Swagger UI 'Try it out' does not respect sub-path / tries to call root \<host\>/rest-api/... Manual call to correct  \<host\>/web/rest-api/...  url works fine.                  |
+| [vis](https://github.com/ioBroker/ioBroker.vis)         | ❌ | —                            | Not path‑aware; UI broken behind a sub‑path                                                                                                                                      |
+| [vis-2](https://github.com/ioBroker/ioBroker.vis-2)     | ⚠️ | —                            | Generally path tolerant; custom widgets or legacy resources may use absolute paths. Also see *1                                                                                  |
+| [web](https://github.com/ioBroker/ioBroker.web)         | ✅ | —                            | Base for web‑hosted adapter UIs; proxy under e.g. `/web/`. Important: Also requires correct configuration of web adapter: see bellow "6. Configuring Web Adapter"                |
+| [welcome](https://github.com/ioBroker/ioBroker.welcome) | ✅ | —                            |                                                                                                                                                                                  |
+| [energiefluss-erweitert](https://github.com/SKB-CGN/ioBroker.energiefluss-erweitert)     | ⚠️ | —                            | The kindly provided fix was refused. You might want to consider using [energiefluss-erweitert-ng](https://github.com/SimonFischer04/ioBroker.energiefluss-erweitert-ng) instead. |
 * Mixed content: If you terminate TLS at the proxy (HTTPS) but contact adapters over HTTP internally, make sure all external links are rewritten to HTTPS to avoid browser mixed-content blocks.
-* WebSocket forwarding: Ensure `Upgrade` and `Connection` headers are passed through. In Nginx, this typically means adding (also for custom locations like `/web/` !):
+* WebSocket forwarding: Ensure `Upgrade` and `Connection` headers are passed through. In Nginx, this typically means adding (also for custom locations like `/web/` and `/admin/` !):
 ```
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection "upgrade";
@@ -125,7 +136,8 @@ location /icons-material-png  => http://LOCAL_IOBROKER_IP:8082
 
 | Symptom                            | Likely cause                         | Action                                                |
 |------------------------------------|--------------------------------------|-------------------------------------------------------|
-| Blank or partial Admin UI          | Admin mounted under sub‑path only    | Keep Admin at `/` (see limitation)                    |
+| Blank or partial Admin UI          | Prefix not stripped, or `admin.0` missing from the Reverse Proxy tab | Add `admin.0` and proxy `location /admin/` to `http://IP:8081/` (strip the prefix) |
+| Socket goes to `ws://host/?sid=…`  | `admin.0` not listed, or stale admin build | List `admin.0` → `/admin/`; hard-reload. Direct `:8081/admin/` also works. |
 | Adapter link opens wrong host/port | Missing entry in Reverse Proxy tab   | Add mapping row and save                              |
 | 404 for adapter JS/CSS             | Missing trailing slash in location   | Add trailing slash to location and mapping            |
 | WebSocket errors in console        | Proxy not forwarding upgrade headers | Add `proxy_set_header Upgrade` / `Connection` headers |

--- a/admin/jsonConfig.json5
+++ b/admin/jsonConfig.json5
@@ -320,7 +320,7 @@
             items: {
                 _explanation: {
                     type: 'staticText',
-                    text: 'You can use admin behind a reverse proxy.',
+                    text: 'You can use admin behind a reverse proxy. Add this admin instance as f.e. /admin/.',
                 },
                 reverseProxy: {
                     xs: 12,
@@ -335,7 +335,7 @@
                             attr: 'globalPath',
                             filter: false,
                             sort: false,
-                            default: '/iobroker/',
+                            default: '/',
                         },
                         // {"type": "text", "width": "20%", "title": "Domain", "attr": "domain", "filter": false, "sort": false, "default": "*"},
                         { type: 'staticText', text: '=>', noTranslation: true, width: 20 },
@@ -345,7 +345,10 @@
                             attr: 'paths',
                             filter: false,
                             sort: false,
-                            default: [{ instance: 'web.0', path: '/web/' }],
+                            default: [
+                                { instance: 'admin.0', path: '/admin/' },
+                                { instance: 'web.0', path: '/web/' },
+                            ],
                             items: [
                                 {
                                     type: 'instance',

--- a/src-admin/index.html
+++ b/src-admin/index.html
@@ -80,6 +80,7 @@
             window.loadingBackgroundImage = '@@loadingBackgroundImage@@';
             window.loadingHideLogo = '@@loadingHideLogo@@';
             window.ssoActive = '@@ssoActive@@';
+            window.socketPath = '@@socketPath@@';
         </script>
         <style>
             .root {

--- a/src-admin/public/js/adapter-settings.js
+++ b/src-admin/public/js/adapter-settings.js
@@ -7,12 +7,8 @@ const path = location.pathname;
 let parts = path.split('/');
 parts.splice(-3);
 
-if (location.pathname.match(/^\/admin\//)) {
-    parts = [];
-}
-
 var systemConfig;
-var socket = io.connect('/', { path: `${parts.join('/')}/socket.io` });
+var socket = io.connect(window.socketPath || '/', { path: `${parts.join('/')}/socket.io` });
 const query = (window.location.search || '').replace(/^\?/, '').replace(/#.*$/, '');
 const args = {};
 var theme = null;

--- a/src-admin/src/App.tsx
+++ b/src-admin/src/App.tsx
@@ -3031,7 +3031,7 @@ class App extends Router<AppProps, AppState> {
                             ) : null}
                             <Grid>
                                 <a
-                                    href="/#easy"
+                                    href="#easy"
                                     onClick={event => event.preventDefault()}
                                     style={{ color: 'inherit', textDecoration: 'none' }}
                                 >

--- a/src-admin/src/components/Chat/ChatMcpInfoDialog.tsx
+++ b/src-admin/src/components/Chat/ChatMcpInfoDialog.tsx
@@ -19,6 +19,7 @@ import { Check as CheckIcon, Close as CloseIcon, ContentCopy as CopyIcon } from 
 import { I18n, type AdminConnection, type ThemeType } from '@iobroker/gui-components';
 
 import { type ChatMcpInfoResponse, type ChatMode, type McpEndpoint } from './chatTypes';
+import { adminHref } from '@/helpers/utils';
 
 interface ChatMcpInfoDialogProps {
     socket: AdminConnection;
@@ -38,7 +39,7 @@ function endpointUrl(ep: McpEndpoint): string {
     // The admin instance embeds MCP on its OWN web server → reuse the current origin (this also keeps
     // a reverse proxy / custom port correct). Other instances are reached on their own port.
     if (ep.kind === 'admin') {
-        return `${window.location.origin}/mcp`;
+        return `${window.location.origin}${adminHref('mcp')}`;
     }
     return `${ep.secure ? 'https' : 'http'}://${window.location.hostname}:${ep.port}/mcp`;
 }

--- a/src-admin/src/components/Drawer.tsx
+++ b/src-admin/src/components/Drawer.tsx
@@ -738,7 +738,7 @@ class Drawer extends Component<DrawerProps, DrawerState> {
                     }}
                 >
                     <a
-                        href="/#easy"
+                        href="#easy"
                         onClick={event => event.preventDefault()}
                         style={{ color: 'inherit', textDecoration: 'none' }}
                     >

--- a/src-admin/src/components/Users/UserEditDialog.tsx
+++ b/src-admin/src/components/Users/UserEditDialog.tsx
@@ -17,6 +17,8 @@ import {
 
 import { Utils, IconPicker, type Translate } from '@iobroker/gui-components';
 
+import { adminHref } from '@/helpers/utils';
+
 import { IOTextField, IOColorPicker } from '../IOFields/Fields';
 import AdminUtils from '../../helpers/AdminUtils';
 
@@ -335,7 +337,9 @@ export default class UserEditDialog extends Component<UserEditDialogProps, UserE
                 color="secondary"
                 fullWidth
                 onClick={() => {
-                    window.location.href = `/sso?redirectUrl=${encodeURIComponent(`${window.origin}/#tab-users`)}&method=register&user=${this.props.getText(this.props.user.common.name)}`;
+                    window.location.href = adminHref(
+                        `sso?redirectUrl=${encodeURIComponent(`${window.origin}${adminHref('#tab-users')}`)}&method=register&user=${this.props.getText(this.props.user.common.name)}`,
+                    );
                 }}
                 startIcon={<PersonIcon />}
                 sx={{ marginTop: 2 }}

--- a/src-admin/src/dialogs/WizardDialog.tsx
+++ b/src-admin/src/dialogs/WizardDialog.tsx
@@ -27,6 +27,7 @@ import WizardAuthSSLTab from '@/components/Wizard/WizardAuthSSLTab';
 import WizardPortForwarding from '@/components/Wizard/WizardPortForwarding';
 import WizardAdaptersTab from '@/components/Wizard/WizardAdaptersTab';
 import WizardRoomsTab from '@/components/Wizard/WizardRoomsTab';
+import { adminHref } from '@/helpers/utils';
 
 const TOOLBAR_HEIGHT = 64;
 
@@ -327,7 +328,7 @@ class WizardDialog extends Component<WizardDialogProps, WizardDialogState> {
                         await this.props.socket.setObject(this.adminInstance._id, this.adminInstance);
                         setTimeout(
                             () =>
-                                (window.location.href = `http://${window.location.host}/#tab-adapters${discovery?.val ? '/discovery' : ''}`),
+                                (window.location.href = `http://${window.location.host}${adminHref(`#tab-adapters${discovery?.val ? '/discovery' : ''}`)}`),
                             1000,
                         );
                         this.props.onClose();
@@ -343,9 +344,9 @@ class WizardDialog extends Component<WizardDialogProps, WizardDialogState> {
                 // redirect to https or http
                 let redirect;
                 if (this.adminInstance.native.secure) {
-                    redirect = `https://${window.location.host}/#tab-adapters${discovery?.val ? '/discovery' : ''}`;
+                    redirect = `https://${window.location.host}${adminHref(`#tab-adapters${discovery?.val ? '/discovery' : ''}`)}`;
                 } else {
-                    redirect = `http://${window.location.host}/#tab-adapters${discovery?.val ? '/discovery' : ''}`;
+                    redirect = `http://${window.location.host}${adminHref(`#tab-adapters${discovery?.val ? '/discovery' : ''}`)}`;
                 }
 
                 this.props.onClose(redirect);

--- a/src-admin/src/globals.d.ts
+++ b/src-admin/src/globals.d.ts
@@ -5,6 +5,11 @@ declare global {
         _sessionStorage?: Storage;
         /** Vendor prefix, used to select the vendor-specific loader ('PT', 'MV', 'NW', 'HA', ...) */
         vendorPrefix: undefined | string;
+        /**
+         * Public path of this admin instance (`/` or e.g. `/admin/`).
+         * Injected by the server from the reverse-proxy table.
+         */
+        socketPath?: string;
     }
 
     declare module '*.svg';

--- a/src-admin/src/helpers/utils.ts
+++ b/src-admin/src/helpers/utils.ts
@@ -522,6 +522,36 @@ export interface ReverseProxyItem {
     paths: { path: string; instance: string }[];
 }
 
+/**
+ * Public path of this admin instance from the reverse-proxy table.
+ * Looks up `admin.0` and joins it with `globalPath`.
+ * Returns `/` when the instance is not listed.
+ */
+export function getAdminPublicPath(
+    reverseProxy: ReverseProxyItem[] | undefined | null,
+    adminInstance: string,
+): string {
+    if (!reverseProxy?.length) {
+        return '/';
+    }
+    for (const group of reverseProxy) {
+        const entry = group.paths?.find(item => item.instance === adminInstance);
+        if (entry) {
+            return `${group.globalPath || '/'}${entry.path || ''}`.replace(/\/+/g, '/') || '/';
+        }
+    }
+    return '/';
+}
+
+/** `adminHref('oauth/token')` → `/admin/oauth/token` when `window.socketPath` is `/admin/`. */
+export function adminHref(path: string): string {
+    // allow / dont modify absolute urls f.e. CustomTab href from adminTab.link
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+        return path;
+    }
+    return (window.socketPath || '/') + path.replace(/^\//, '');
+}
+
 // New util returning rewritten link (used by Intro & Instances simplified usage)
 export function applyReverseProxyToLink(
     link: string | undefined,

--- a/src-admin/src/helpers/utils.ts
+++ b/src-admin/src/helpers/utils.ts
@@ -527,10 +527,7 @@ export interface ReverseProxyItem {
  * Looks up `admin.0` and joins it with `globalPath`.
  * Returns `/` when the instance is not listed.
  */
-export function getAdminPublicPath(
-    reverseProxy: ReverseProxyItem[] | undefined | null,
-    adminInstance: string,
-): string {
+export function getAdminPublicPath(reverseProxy: ReverseProxyItem[] | undefined | null, adminInstance: string): string {
     if (!reverseProxy?.length) {
         return '/';
     }

--- a/src-admin/src/login/Login.tsx
+++ b/src-admin/src/login/Login.tsx
@@ -19,6 +19,8 @@ import { Visibility } from '@mui/icons-material';
 
 import { type IobTheme, I18n, Connection } from '@iobroker/gui-components';
 
+import { adminHref } from '@/helpers/utils';
+
 export interface OAuth2Response {
     access_token: string;
     expires_in: number;
@@ -96,6 +98,8 @@ declare global {
         loginTitle: string;
         /** If the SSO feature is active, it is set to string 'true' */
         ssoActive: string;
+        /** Public path of this admin instance, injected by the server */
+        socketPath?: string;
     }
 }
 
@@ -170,7 +174,7 @@ export default class Login extends Component<object, LoginState> {
         const tokens = Connection.readTokens();
 
         if (tokens?.refresh_token) {
-            void fetch('../oauth/token', {
+            void fetch(adminHref('oauth/token'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
@@ -202,7 +206,7 @@ export default class Login extends Component<object, LoginState> {
 
     onLogin(): void {
         this.setState({ inProcess: true, error: '' }, async () => {
-            const response = await fetch('../oauth/token', {
+            const response = await fetch(adminHref('oauth/token'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded',
@@ -383,7 +387,9 @@ export default class Login extends Component<object, LoginState> {
                         {window.ssoActive === 'true' ? (
                             <Button
                                 onClick={() => {
-                                    window.location.href = `/sso?redirectUrl=${encodeURIComponent(`${window.origin}/#tab-intro`)}&method=login`;
+                                    window.location.href = adminHref(
+                                        `sso?redirectUrl=${encodeURIComponent(`${window.origin}${adminHref('#tab-intro')}`)}&method=login`,
+                                    );
                                 }}
                                 fullWidth
                                 variant="contained"

--- a/src-admin/src/tabs/Config.tsx
+++ b/src-admin/src/tabs/Config.tsx
@@ -51,6 +51,7 @@ import { type DeviceManagerPropsProps, JsonConfig } from '@iobroker/json-config'
 import DeviceManager from '@iobroker/dm-gui-components';
 
 import AdminUtils from '../helpers/AdminUtils';
+import { adminHref } from '../helpers/utils';
 
 const arrayLogLevel: ioBroker.LogLevel[] = ['silly', 'debug', 'info', 'warn', 'error'];
 
@@ -485,7 +486,7 @@ class Config extends Component<ConfigProps, ConfigState> {
                     }}
                     title="config"
                     style={this.props.style}
-                    src={src}
+                    src={adminHref(src)}
                 ></iframe>
             );
         }

--- a/src-admin/src/tabs/CustomTab.tsx
+++ b/src-admin/src/tabs/CustomTab.tsx
@@ -13,6 +13,7 @@ import {
 
 import type { InstancesWorker } from '@/Workers/InstancesWorker';
 import AdminUtils from '@/helpers/AdminUtils';
+import { adminHref } from '@/helpers/utils';
 import type { CompactHost } from '@/types';
 
 const styles: Record<string, React.CSSProperties> = {
@@ -154,7 +155,7 @@ export default class CustomTab extends Component<CustomTabProps, CustomTabState>
         }
 
         this.setState({
-            href: result.href,
+            href: adminHref(result.href),
             adapterName: result.adapterName,
             instanceNumber: result.instanceNumber,
             schema,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -527,10 +527,7 @@ export interface ReverseProxyItem {
  * Looks up `admin.0` and joins it with `globalPath`.
  * Returns `/` when the instance is not listed.
  */
-export function getAdminPublicPath(
-    reverseProxy: ReverseProxyItem[] | undefined | null,
-    adminInstance: string,
-): string {
+export function getAdminPublicPath(reverseProxy: ReverseProxyItem[] | undefined | null, adminInstance: string): string {
     if (!reverseProxy?.length) {
         return '/';
     }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -522,6 +522,27 @@ export interface ReverseProxyItem {
     paths: { path: string; instance: string }[];
 }
 
+/**
+ * Public path of this admin instance from the reverse-proxy table.
+ * Looks up `admin.0` and joins it with `globalPath`.
+ * Returns `/` when the instance is not listed.
+ */
+export function getAdminPublicPath(
+    reverseProxy: ReverseProxyItem[] | undefined | null,
+    adminInstance: string,
+): string {
+    if (!reverseProxy?.length) {
+        return '/';
+    }
+    for (const group of reverseProxy) {
+        const entry = group.paths?.find(item => item.instance === adminInstance);
+        if (entry) {
+            return `${group.globalPath || '/'}${entry.path || ''}`.replace(/\/+/g, '/') || '/';
+        }
+    }
+    return '/';
+}
+
 // New util returning rewritten link (used by Intro & Instances simplified usage)
 export function applyReverseProxyToLink(
     link: string | undefined,

--- a/src/lib/web.ts
+++ b/src/lib/web.ts
@@ -653,9 +653,7 @@ export default class Web {
                     }
                 });
             } else {
-                this.server.app.get('/logout', (_req: Request, res: Response): void =>
-                    res.redirect(this.publicPath),
-                );
+                this.server.app.get('/logout', (_req: Request, res: Response): void => res.redirect(this.publicPath));
             }
 
             this.server.app.get('/iobroker_check.html', (_req: Request, res: Response): void => {

--- a/src/lib/web.ts
+++ b/src/lib/web.ts
@@ -21,6 +21,7 @@ import cookieParser from 'cookie-parser';
 import type { InternalStorageToken } from '@iobroker/socket-classes';
 import { McpServer, type McpConfig } from '@iobroker/mcp-server';
 import type { AdminAdapterConfig } from '../types';
+import { getAdminPublicPath } from './utils';
 
 let AdapterStore;
 /** Content of a socket-io file */
@@ -139,7 +140,16 @@ export default class Web {
         server: null,
     };
 
-    private readonly LOGIN_PAGE = '/index.html?login';
+    /**
+     * Configured public mount (`/` or `/admin/`), like web `rootPath`.
+     * Incoming `/admin/…` is stripped so `:8081/admin/` and the proxy share one path.
+     */
+    private readonly publicPath: string;
+
+    /** Login URL as the browser must see it. */
+    private get loginPage(): string {
+        return `${this.publicPath}index.html?login`;
+    }
 
     /** URL to the JSON config schema */
     private readonly JSON_CONFIG_SCHEMA_URL =
@@ -194,6 +204,7 @@ export default class Web {
         this.options = options;
 
         this.systemLanguage = this.options?.systemLanguage || 'en';
+        this.publicPath = getAdminPublicPath(this.settings.reverseProxy, this.adapter.namespace);
 
         void this.#init();
     }
@@ -278,6 +289,9 @@ export default class Web {
                 template = template.replace(`@@loginLink@@`, this.systemConfig.native?.vendor.admin.login.link || '');
             } else if (pattern === 'loginTitle') {
                 template = template.replace(`@@loginTitle@@`, this.systemConfig.native?.vendor.admin.login.title || '');
+            } else if (pattern === 'socketPath') {
+                // Same as web `rootPath`: WS URL only. Empty when admin is at `/`.
+                template = template.replace(/@@socketPath@@/g, this.publicPath === '/' ? '' : this.publicPath);
             } else {
                 template = template.replace(
                     `@@${pattern}@@`,
@@ -293,6 +307,9 @@ export default class Web {
 
     getInfoJs(): string {
         const result = [`window.sysLang = "${this.systemLanguage}";`];
+        if (this.publicPath && this.publicPath !== '/') {
+            result.push(`window.socketPath = ${JSON.stringify(this.publicPath)};`);
+        }
         if (uuid?.length === 38) {
             result.push(`window.vendorPrefix = "${uuid.substring(0, 2)}";`);
         }
@@ -319,17 +336,17 @@ export default class Web {
                 origin = parts.join('&');
             }
             if (origin.startsWith('?login')) {
-                return this.LOGIN_PAGE + origin.substring(6);
+                return this.loginPage + origin.substring(6);
             }
             if (origin.startsWith('/?login')) {
-                return this.LOGIN_PAGE + origin.substring(7);
+                return this.loginPage + origin.substring(7);
             }
-            if (origin.startsWith(this.LOGIN_PAGE)) {
+            if (origin.startsWith(this.loginPage)) {
                 return origin;
             }
-            return this.LOGIN_PAGE + origin;
+            return this.loginPage + origin;
         }
-        return `${this.LOGIN_PAGE}?error`;
+        return `${this.loginPage}?error`;
     }
 
     /**
@@ -425,6 +442,14 @@ export default class Web {
 
             this.server.app.disable('x-powered-by');
 
+            // Middleware to strip sub-path like '/admin/' so ip:8081/ still works even when proxy configuration is present
+            this.server.app.use((req: Request, _res: Response, next: NextFunction): void => {
+                if (this.publicPath !== '/') {
+                    req.url = req.url.replace(this.publicPath, '/');
+                }
+                next();
+            });
+
             // enable use of i-frames together with HTTPS
             this.server.app.get('/*any', (_req: Request, res: Response, next: NextFunction): void => {
                 res.header('X-Frame-Options', 'SAMEORIGIN');
@@ -515,7 +540,7 @@ export default class Web {
                             return 'http://127.0.0.1:3000/index.html?login';
                         }
 
-                        return origin ? origin + this.LOGIN_PAGE : this.LOGIN_PAGE;
+                        return origin ? `${origin}/index.html?login` : this.loginPage;
                     },
                 });
 
@@ -557,7 +582,7 @@ export default class Web {
                     if (isDev) {
                         res.redirect('http://127.0.0.1:3000/index.html?login');
                     } else {
-                        res.redirect(origin ? origin + this.LOGIN_PAGE : this.LOGIN_PAGE);
+                        res.redirect(origin ? `${origin}/index.html?login` : this.loginPage);
                     }
                 });
 
@@ -615,7 +640,9 @@ export default class Web {
                                 file.isDir ? pathName.startsWith(`/${file.name}/`) : `/${file.name}` === pathName,
                             )
                         ) {
-                            res.redirect(`${this.LOGIN_PAGE}&href=${encodeURIComponent(req.originalUrl)}`);
+                            res.redirect(
+                                `${this.loginPage}&href=${encodeURIComponent(this.publicPath + req.url.replace(/^\//, ''))}`,
+                            );
                         } else {
                             next();
                             return;
@@ -626,7 +653,9 @@ export default class Web {
                     }
                 });
             } else {
-                this.server.app.get('/logout', (_req: Request, res: Response): void => res.redirect('/'));
+                this.server.app.get('/logout', (_req: Request, res: Response): void =>
+                    res.redirect(this.publicPath),
+                );
             }
 
             this.server.app.get('/iobroker_check.html', (_req: Request, res: Response): void => {

--- a/src/lib/web.ts
+++ b/src/lib/web.ts
@@ -324,6 +324,23 @@ export default class Web {
         return result.join('\n');
     }
 
+    /*
+        force load _socket/info.js so window.socketPath is set for adapters that do not load info.js themselves.
+        (typically tab.html and index.html (admin instance settings page) for non json-config adapters)
+     */
+    private withInfoJs(url: string, body: Buffer | string): Buffer | string {
+        if (this.publicPath === '/' || !/\.html?$/i.test(url.split('?')[0])) {
+            return body;
+        }
+        let html = typeof body === 'string' ? body : body.toString('utf8');
+        if (html.includes('_socket/info.js') || html.includes('window.socketPath')) {
+            return body;
+        }
+        const script = `<script src="${this.publicPath}_socket/info.js"></script>`;
+        html = html.includes('<head>') ? html.replace('<head>', `<head>${script}`) : script + html;
+        return html;
+    }
+
     getErrorRedirect(origin: string): string {
         // LOGIN_PAGE /index.html?login
         // origin can be "?login&href=" -
@@ -1017,7 +1034,7 @@ export default class Web {
                                 res.contentType('text/javascript');
                             }
                         }
-                        res.send(buffer);
+                        res.send(this.withInfoJs(url, buffer));
                     }
                 });
             });

--- a/test/testReplaceLink.js
+++ b/test/testReplaceLink.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 
-const { replaceLink } = require('../build/lib/utils');
+const { replaceLink, getAdminPublicPath } = require('../build/lib/utils');
 
 const instances = {
     'system.adapter.admin.0': {
@@ -7693,4 +7693,42 @@ describe('Test replace link in front-end', function () {
 
         done();
     });
+});
+
+describe('admin public path (reverse proxy)', () => {
+    describe('getAdminPublicPath', () => {
+        it('returns / when reverseProxy is empty', () => {
+            assert.strictEqual(getAdminPublicPath([], 'admin.0'), '/');
+            assert.strictEqual(getAdminPublicPath(undefined, 'admin.0'), '/');
+        });
+
+        it('joins globalPath with the admin instance path', () => {
+            assert.strictEqual(
+                getAdminPublicPath(
+                    [
+                        {
+                            globalPath: '/iobroker',
+                            paths: [
+                                { instance: 'admin.0', path: '/admin/' },
+                                { instance: 'web.0', path: '/web/' },
+                            ],
+                        },
+                    ],
+                    'admin.0',
+                ),
+                '/iobroker/admin/',
+            );
+        });
+
+        it('returns / when this admin instance is not listed', () => {
+            assert.strictEqual(
+                getAdminPublicPath(
+                    [{ globalPath: '/iobroker/', paths: [{ instance: 'web.0', path: '/web/' }] }],
+                    'admin.0',
+                ),
+                '/',
+            );
+        });
+    });
+
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -24,3 +24,5 @@ tests.unit(path.join(__dirname, '..'), {
         '{CONTROLLER_DIR}/lib/letsencrypt': jscLEMock,
     },
 });
+
+require('./testReplaceLink');


### PR DESCRIPTION
Erlaubt es admin hinter einem reverse-proxy auf nicht root Pfad zu betreiben. z.B. '/admin'

Alle Pfade sind jetzt relativ / verwenden rootPath, der aus der reverse Proxy Tabelle in den Admin settings extrahiert wird.

Bin mal so frei @klein0r zu taggen: Ist für dein HA Ding wahrscheinlich auch interessant. Wenn noch fragen sind (generell zum reverse-proxy Betrieb) generne Melden, hab das in der letzten Zeit durch einige Adapter durchgezogen / gefixt.

Inklusiv Beispiel: Closes #1660 und Docs. PS: Glaub beim letzten merge damals ist was schiefgelaufen. Der example Abschnitt in der Readme wird nicht mehr gebraucht und ist outdated. Ist jetzt in einem eigenen File.